### PR TITLE
Add combo packet

### DIFF
--- a/src/NosCore.Packets/Enumerations/KeyBind.cs
+++ b/src/NosCore.Packets/Enumerations/KeyBind.cs
@@ -19,7 +19,7 @@
 
 namespace NosCore.Packets.Enumerations
 {
-    public enum KeyBind : byte
+    public enum KeyBind : short
     {
 		SameKey = -1,
 		CtrlA	= 0

--- a/src/NosCore.Packets/Enumerations/KeyBind.cs
+++ b/src/NosCore.Packets/Enumerations/KeyBind.cs
@@ -1,0 +1,27 @@
+﻿//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// 
+// Copyright (C) 2019 - NosCore
+// 
+// NosCore is a free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace NosCore.Packets.Enumerations
+{
+    public enum KeyBind : byte
+    {
+		SameKey = -1,
+		CtrlA	= 0
+    }
+}

--- a/src/NosCore.Packets/ServerPackets/Battle/MslotPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Battle/MslotPacket.cs
@@ -26,7 +26,7 @@ namespace NosCore.Packets.ServerPackets.Battle
     public class MslotPacket : PacketBase
     {
 		[PacketIndex(0)]
-		public byte SkillCastId { get; set; }
+		public long SkillCastId { get; set; }
 
 		[PacketIndex(1)]
 		public KeyBind KeyId { get; set; }

--- a/src/NosCore.Packets/ServerPackets/Battle/MslotPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Battle/MslotPacket.cs
@@ -1,0 +1,34 @@
+﻿//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// 
+// Copyright (C) 2019 - NosCore
+// 
+// NosCore is a free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using NosCore.Packets.Attributes;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.Packets.ServerPackets.Battle
+{
+    [PacketHeader("mslot")]
+    public class MslotPacket : PacketBase
+    {
+		[PacketIndex(0)]
+		public byte SkillCastId { get; set; }
+
+		[PacketIndex(1)]
+		public KeyBind KeyId { get; set; }
+    }
+}


### PR DESCRIPTION
Mslot packet is used to show player a combo has been unlocked. The key he will have to use is set by KeyId. -1 will be the same key as he used to unlock the combo, 0 will be ctrl+A.