### PR TITLE
Add EInfoNpcMonsterPacket for req_info NPC/mate responses

### DIFF
--- a/documentation/DocumentationTest.PacketsDocumentation.verified.md
+++ b/documentation/DocumentationTest.PacketsDocumentation.verified.md
@@ -309,6 +309,7 @@
 - [pjoin](../src/NosCore.Packets/ServerPackets/Groups/PjoinPacket.cs) *InGame*
 
 ### Inventory
+- [e_info](../src/NosCore.Packets/ServerPackets/Inventory/EInfoNpcMonsterPacket.cs) *InGame*
 - [e_info](../src/NosCore.Packets/ServerPackets/Inventory/EInfoPacket.cs) *InGame*
 - [eq](../src/NosCore.Packets/ServerPackets/Inventory/EqPacket.cs) *InGame*
 - [equip](../src/NosCore.Packets/ServerPackets/Inventory/EquipPacket.cs) *InGame*

--- a/src/NosCore.Packets/Attributes/PacketHeaderAttribute.cs
+++ b/src/NosCore.Packets/Attributes/PacketHeaderAttribute.cs
@@ -24,5 +24,14 @@ namespace NosCore.Packets.Attributes
         public string Identification { get; set; }
 
         public Scope Scopes { get; set; }
+
+        /// <summary>
+        ///     Set true when the wire-level header is legitimately shared with another
+        ///     packet class that distinguishes itself by a leading discriminator field
+        ///     (e.g. e_info subtype 0-5/8 for items vs subtype 10 for NPC/mate in OpenNos).
+        ///     Only meaningful for server-only packets — client packets still need a
+        ///     1:1 header mapping because the parser looks up the class by header alone.
+        /// </summary>
+        public bool AllowDuplicateHeader { get; set; }
     }
 }

--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>16.1.0</Version>
+		<Version>16.2.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Packets/ServerPackets/Inventory/EInfoNpcMonsterPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Inventory/EInfoNpcMonsterPacket.cs
@@ -14,7 +14,7 @@ namespace NosCore.Packets.ServerPackets.Inventory
     // same 26-field layout from NpcMonster.GenerateEInfo / Mate.GenerateEInfo,
     // so we share a single packet class. Field order and types match the
     // OpenNos format string verbatim — reordering will break the client tooltip.
-    [PacketHeader("e_info", Scope.InGame)]
+    [PacketHeader("e_info", Scope.InGame, AllowDuplicateHeader = true)]
     public class EInfoNpcMonsterPacket : PacketBase
     {
         [PacketIndex(0)]

--- a/src/NosCore.Packets/ServerPackets/Inventory/EInfoNpcMonsterPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Inventory/EInfoNpcMonsterPacket.cs
@@ -1,0 +1,98 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using NosCore.Packets.Attributes;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.Packets.ServerPackets.Inventory
+{
+    // e_info subtype 10 — response the server emits when a client sends
+    // req_info 5 (NPC monster) or req_info 6 (mate). OpenNos builds the
+    // same 26-field layout from NpcMonster.GenerateEInfo / Mate.GenerateEInfo,
+    // so we share a single packet class. Field order and types match the
+    // OpenNos format string verbatim — reordering will break the client tooltip.
+    [PacketHeader("e_info", Scope.InGame)]
+    public class EInfoNpcMonsterPacket : PacketBase
+    {
+        [PacketIndex(0)]
+        public byte SubType { get; set; } = 10;
+
+        [PacketIndex(1)]
+        public short NpcMonsterVNum { get; set; }
+
+        [PacketIndex(2)]
+        public byte Level { get; set; }
+
+        [PacketIndex(3)]
+        public byte Element { get; set; }
+
+        [PacketIndex(4)]
+        public byte AttackClass { get; set; }
+
+        [PacketIndex(5)]
+        public short ElementRate { get; set; }
+
+        [PacketIndex(6)]
+        public byte AttackUpgrade { get; set; }
+
+        [PacketIndex(7)]
+        public short DamageMinimum { get; set; }
+
+        [PacketIndex(8)]
+        public short DamageMaximum { get; set; }
+
+        [PacketIndex(9)]
+        public short Concentrate { get; set; }
+
+        [PacketIndex(10)]
+        public byte CriticalChance { get; set; }
+
+        [PacketIndex(11)]
+        public short CriticalRate { get; set; }
+
+        [PacketIndex(12)]
+        public byte DefenceUpgrade { get; set; }
+
+        [PacketIndex(13)]
+        public short CloseDefence { get; set; }
+
+        [PacketIndex(14)]
+        public short DefenceDodge { get; set; }
+
+        [PacketIndex(15)]
+        public short DistanceDefence { get; set; }
+
+        [PacketIndex(16)]
+        public short DistanceDefenceDodge { get; set; }
+
+        [PacketIndex(17)]
+        public short MagicDefence { get; set; }
+
+        [PacketIndex(18)]
+        public short FireResistance { get; set; }
+
+        [PacketIndex(19)]
+        public short WaterResistance { get; set; }
+
+        [PacketIndex(20)]
+        public short LightResistance { get; set; }
+
+        [PacketIndex(21)]
+        public short DarkResistance { get; set; }
+
+        [PacketIndex(22)]
+        public int MaxHp { get; set; }
+
+        [PacketIndex(23)]
+        public int MaxMp { get; set; }
+
+        [PacketIndex(24)]
+        public int Unknown { get; set; } = -1;
+
+        [PacketIndex(25)]
+        public string? Name { get; set; }
+    }
+}

--- a/src/NosCore.Packets/ServerPackets/Inventory/EInfoPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Inventory/EInfoPacket.cs
@@ -10,7 +10,10 @@ using NosCore.Packets.Enumerations;
 namespace NosCore.Packets.ServerPackets.Inventory
 {
     //todo cleanup this messy packet
-    [PacketHeader("e_info", Scope.InGame)]
+    // e_info is shared with EInfoNpcMonsterPacket (subtype 10). The leading EInfoType
+    // byte acts as the discriminator on the wire — item subtypes 0-5/8 route here,
+    // monster/mate subtype 10 routes to the sibling class.
+    [PacketHeader("e_info", Scope.InGame, AllowDuplicateHeader = true)]
     public class EInfoPacket : PacketBase
     {
         [PacketIndex(0)]

--- a/test/NosCore.Packets.Tests/DocumentationTest.cs
+++ b/test/NosCore.Packets.Tests/DocumentationTest.cs
@@ -66,6 +66,17 @@ namespace NosCore.Packets.Tests
                 .GroupBy(packet => packet.GetCustomAttribute<PacketHeaderAttribute>()!.Identification);
             foreach (var packet in serverPackets.Where(x => x.Count() > 1))
             {
+                // Opt-in duplicates: classes decorated with AllowDuplicateHeader=true model
+                // OpenNos headers that legitimately carry multiple shapes discriminated by
+                // a leading subtype field (e.g. e_info). All shapes under the header must
+                // set the flag — otherwise we fail, because a silent duplicate likely
+                // signals a copy-paste mistake.
+                var duplicates = packet.ToList();
+                if (duplicates.All(t => t.GetCustomAttribute<PacketHeaderAttribute>()!.AllowDuplicateHeader))
+                {
+                    continue;
+                }
+
                 Assert.Fail($"header {packet.Key} has duplicate server packet definition");
             }
         }


### PR DESCRIPTION
## Summary
- Add `EInfoNpcMonsterPacket` (e_info subtype 10) mirroring OpenNos's `NpcMonster.GenerateEInfo` / `Mate.GenerateEInfo` verbatim
- Bump to 16.2.0
- Unblocks `req_info 5` (NPC right-click) and `req_info 6` (mate info) responses on NosCore which currently fall through to a warning log

## Why
NosCore's stock `EInfoPacket` is item-oriented (subtype 0-5, 8). OpenNos's `BasicPacketHandler.ReqInfo` handler answers NPC/mate queries with a different 26-field layout under the same `e_info` header. Without this class NosCore can't construct the monster/mate tooltip response at all.

## Test plan
- [ ] Build `NosCore.Packets`
- [ ] Consume from a downstream server, send an `e_info 10 ...` packet, verify the NosTale client renders the monster tooltip
- [ ] Confirm no regression on existing item `e_info` serialization (two packet classes share the header; serialization picks via the class passed to `SendPacketAsync`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)