### PR TITLE
Extend StPacket to match official shape

### DIFF
--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>16.2.0</Version>
+		<Version>16.4.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Packets/ServerPackets/Entities/StPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Entities/StPacket.cs
@@ -38,7 +38,16 @@ namespace NosCore.Packets.ServerPackets.Entities
         [PacketIndex(7)]
         public int CurrentMp { get; set; }
 
-        [PacketListIndex(8, ListSeparator = " ", IsOptional = true)]
+        [PacketIndex(8)]
+        public int MaxHp { get; set; }
+
+        [PacketIndex(9)]
+        public int MaxMp { get; set; }
+
+        [PacketIndex(10)]
+        public byte Unknown1 { get; set; }
+
+        [PacketListIndex(11, ListSeparator = " ", IsOptional = true)]
         public List<short>? BuffIds { get; set; }
     }
 }

--- a/test/NosCore.Packets.Tests/DeserializerTest.cs
+++ b/test/NosCore.Packets.Tests/DeserializerTest.cs
@@ -262,7 +262,7 @@ namespace NosCore.Packets.Tests
         public void DeserializeSimpleListWithoutSpaceSeparator()
         {
             var packet = (StPacket)Deserializer.Deserialize(
-                "st 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16"
+                "st 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19"
                 );
             Assert.HasCount(8, packet.BuffIds!);
         }


### PR DESCRIPTION
## Summary
- Add \`MaxHp\`, \`MaxMp\`, and a trailing \`Unknown1\` byte to \`StPacket\`
- Shift the optional buff list from index 8 -> 11
- Bump to \`16.4.0\`

## Why
Every captured \`st\` packet from a live session of the official server has 11 values, not 8:

\`\`\`
st 2 3019 35 0 100 100 1360 630 1360 630 0
st 3 2848 2 0 100 100 175 15 175 15 0
\`\`\`

OpenNos \`StaticPacketHelper.GenerateSt\` stopped at \`currentHp\`/\`currentMp\` and appended an inline buff list. The modern client added MaxHp/MaxMp plus a trailing reserved byte (consistently \`0\` across every NPC and monster capture) before the buff list. Without the trailing byte the client parser misaligns — the selected-target HP bar doesn't animate on hit even though the HP/MP values in the packet are correct.

Layered on top of the pending 16.3.0 shape fixes.

## Test plan
- [x] \`dotnet test\` — all 71 tests pass (deserializer test input extended to account for the three new fields so the buff-list count assertion still matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)