### PR TITLE
chore: bump Microsoft.CodeAnalysis.CSharp to 5.3.0

### DIFF
--- a/test/NosCore.Packets.Benchmark/NosCore.Packets.Benchmark.csproj
+++ b/test/NosCore.Packets.Benchmark/NosCore.Packets.Benchmark.csproj
@@ -10,7 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Bump `Microsoft.CodeAnalysis.CSharp` 4.14.0 → 5.3.0 in the benchmark project. All 71 tests pass. Supersedes #431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)