### PR TITLE
Add JobClass field to Char_NEW_JOB for level-56 specialist creation

### DIFF
--- a/src/NosCore.Packets/ClientPackets/CharacterSelectionScreen/CharNewJobPacket.cs
+++ b/src/NosCore.Packets/ClientPackets/CharacterSelectionScreen/CharNewJobPacket.cs
@@ -12,9 +12,7 @@ namespace NosCore.Packets.ClientPackets.CharacterSelectionScreen
     [PacketHeader("Char_NEW_JOB", Scope.OnCharacterScreen)]
     public class CharNewJobPacket : CharNewPacket
     {
-        public CharNewJobPacket()
-        {
-            IsMartialArtist = true;
-        }
+        [PacketIndex(5)]
+        public byte? JobClass { get; set; }
     }
 }

--- a/src/NosCore.Packets/ClientPackets/CharacterSelectionScreen/CharNewPacket.cs
+++ b/src/NosCore.Packets/ClientPackets/CharacterSelectionScreen/CharNewPacket.cs
@@ -30,6 +30,6 @@ namespace NosCore.Packets.ClientPackets.CharacterSelectionScreen
         [PacketIndex(4)]
         public HairColorType HairColor { get; set; }
 
-        public bool IsMartialArtist { get; set; }
+        public byte? TargetClass { get; set; }
     }
 }

--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>16.4.0</Version>
+		<Version>16.5.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Replace `CharNewPacket.IsMartialArtist` passthrough flag with a nullable `TargetClass` byte so the handler pipeline can carry any requested class (not only MA).
- Expose the extra `Char_NEW_JOB` wire field (PacketIndex 5) as `JobClass`, enabling server-side routing of level-56 specialist creation (1=MartialArtist, 2=Swordsman, 3=Archer, 4=Mage).
- Bump package version to 16.5.0.

Unblocks the level-56 direct-creation feature in NosCore-pr2058-split.

## Test plan
- [x] `dotnet test test/NosCore.Packets.Tests` — 71/71 pass locally.
- [ ] CI green on PR.
- [ ] After merge, tag `16.5.0` to trigger auto-publish to nuget.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)