### PR TITLE
Extend SuPacket to match official shape (TargetCurrentHp/TargetMaxHp)

### DIFF
--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>16.5.0</Version>
+		<Version>16.6.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Packets/ServerPackets/Battle/SuPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Battle/SuPacket.cs
@@ -57,5 +57,11 @@ namespace NosCore.Packets.ServerPackets.Battle
 
         [PacketIndex(14)]
         public int SkillTypeMinusOne { get; set; }
+
+        [PacketIndex(15)]
+        public int TargetCurrentHp { get; set; }
+
+        [PacketIndex(16)]
+        public int TargetMaxHp { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- Add `TargetCurrentHp` [15] and `TargetMaxHp` [16] to `SuPacket`
- Bump version to 16.6.0

## Why
Every captured `su` packet from a live official session has 17 values, not 15:

```
su 3 2847 2 1454174 0 12 11 200 0 0 1 100 3 0 0 21447 21450
su 1 14293841 3 2847 240 7 11 257 0 0 1 175 0 4 0 175 175
```

The two new trailing integers carry the target's absolute HP for player targets (21447/21450 ≈ real hp/maxhp). Monster targets ship display-scaled values (0/175 on normal hits, max/max on the killing blow). Without them the client parser misaligns and the kill-hit collapse animation never plays.

## Test plan
- [x] `dotnet test test/NosCore.Packets.Tests -v m` — 71/71 pass
- [ ] Wire new fields in NosCore BattleService and confirm death animation shows on live client

🤖 Generated with [Claude Code](https://claude.com/claude-code)