### PR TITLE
Pad list fields to PacketListIndex Length on serialize

### DIFF
--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>16.6.0</Version>
+		<Version>16.7.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Packets/Serializer.cs
+++ b/src/NosCore.Packets/Serializer.cs
@@ -150,6 +150,16 @@ namespace NosCore.Packets
                 isFalse);
         }
 
+        private static IEnumerable<T> PadToMinimumLength<T>(IEnumerable<T>? source, int minimum) where T : new()
+        {
+            var list = source?.ToList() ?? new List<T>();
+            while (list.Count < minimum)
+            {
+                list.Add(new T());
+            }
+            return list;
+        }
+
         private Expression ListSerializer(Expression injectedPacket, Expression specificTypeExpression,
             PacketIndexAttribute indexAttr, Type type, string packetSplitter, Expression propertySplitter)
         {
@@ -164,6 +174,16 @@ namespace NosCore.Packets
             {
                 indexAttr.IsOptional = false;
                 isPacketList = true;
+            }
+
+            if (indexAttr is PacketListIndexAttribute padIndex && padIndex.Length > 0
+                && subtype!.GetConstructor(Type.EmptyTypes) != null)
+            {
+                var padMethod = typeof(Serializer).GetMethod(nameof(PadToMinimumLength),
+                    BindingFlags.NonPublic | BindingFlags.Static)!.MakeGenericMethod(subtype);
+                specificTypeExpression = Expression.Call(padMethod,
+                    specificTypeExpression,
+                    Expression.Constant((int)padIndex.Length));
             }
 
             var selectExp = Expression.Call(

--- a/src/NosCore.Packets/ServerPackets/Quest/QuestSubPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Quest/QuestSubPacket.cs
@@ -24,7 +24,7 @@ namespace NosCore.Packets.ServerPackets.Quest
         [PacketIndex(3)]
         public QuestType GoalType { get; set; }
 
-        [PacketListIndex(4, ListSeparator = ".")]
+        [PacketListIndex(4, ListSeparator = ".", Length = 5)]
         public List<QuestObjectiveSubPacket>? QuestObjectiveSubPackets { get; set; }
 
         [PacketIndex(5)]

--- a/test/NosCore.Packets.Tests/SerializerTest.cs
+++ b/test/NosCore.Packets.Tests/SerializerTest.cs
@@ -198,6 +198,49 @@ namespace NosCore.Packets.Tests
         }
 
         [TestMethod]
+        public void SerializeListPadsToMinimumLength()
+        {
+            var testPacket = new QstlistPacket(new List<QuestSubPacket>
+            {
+                new QuestSubPacket
+                {
+                    ObjectiveCount = 5,
+                    QuestId = 1500,
+                    InfoId = 1500,
+                    GoalType = QuestType.Hunt,
+                    QuestObjectiveSubPackets = new List<QuestObjectiveSubPacket>
+                    {
+                        new QuestObjectiveSubPacket { CurrentCount = 0, MaxCount = 5, IsFinished = false }
+                    },
+                    ShowDialog = true
+                }
+            });
+
+            var packet = Serializer.Serialize(testPacket);
+            Assert.AreEqual("qstlist 5.1500.1500.1.0.5.0.0.0.0.0.0.0.0.0.1", packet);
+        }
+
+        [TestMethod]
+        public void SerializeListPadsEmptyToMinimumLength()
+        {
+            var testPacket = new QstlistPacket(new List<QuestSubPacket>
+            {
+                new QuestSubPacket
+                {
+                    ObjectiveCount = 0,
+                    QuestId = 1997,
+                    InfoId = 1997,
+                    GoalType = QuestType.GoTo,
+                    QuestObjectiveSubPackets = new List<QuestObjectiveSubPacket>(),
+                    ShowDialog = true
+                }
+            });
+
+            var packet = Serializer.Serialize(testPacket);
+            Assert.AreEqual("qstlist 0.1997.1997.19.0.0.0.0.0.0.0.0.0.0.1", packet);
+        }
+
+        [TestMethod]
         public void NullableReferenceInferRequiredAttribute()
         {
             var testPacket = new QstlistPacket(null!);


### PR DESCRIPTION
## Summary
- Serializer now respects the existing `PacketListIndexAttribute.Length` on outgoing packets and pads short lists to the declared minimum (requires a parameterless constructor on the element type).
- Marks `QuestSubPacket.QuestObjectiveSubPackets` with `Length = 5` so `qstlist` matches the official format regardless of how many objectives a quest actually has.
- Unit tests covering the one-item and empty-list padding paths.
- Bumps package to 16.7.0.

Unblocks the "qstlist doesn't show on login" regression in NosCore-pr2058-split.

## Test plan
- [x] `dotnet test` - 73/73 local.
- [ ] CI green.
- [ ] After merge, tag \`16.7.0\` to auto-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)