### PR TITLE
Rename ScriptPacket.Zero to Unknown

### DIFF
--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>16.8.0</Version>
+		<Version>16.8.1</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Packets/ServerPackets/Quest/ScriptPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Quest/ScriptPacket.cs
@@ -13,7 +13,7 @@ namespace NosCore.Packets.ServerPackets.Quest
     public class ScriptPacket : PacketBase
     {
         [PacketIndex(0, IsOptional = true)]
-        public byte? Zero { get; set; }
+        public byte? Unknown { get; set; }
 
         [PacketIndex(1)]
         public int ScriptId { get; set; }

--- a/test/NosCore.Packets.Tests/SerializerTest.cs
+++ b/test/NosCore.Packets.Tests/SerializerTest.cs
@@ -186,7 +186,7 @@ namespace NosCore.Packets.Tests
         {
             var testPacket = new ScriptPacket
             {
-                Zero = 0,
+                Unknown = 0,
                 ScriptId = 1,
                 ScriptStepId = 80
             };


### PR DESCRIPTION
## Summary
- Renames the optional leading field on `ScriptPacket` from `Zero` to `Unknown`.
- Bumps package version to 16.8.1.

## Why
The leading byte on the ack shape (`script 0 <scriptId> <stepId>`) is literally 0 on the wire, but the semantic meaning is not documented. Naming it `Unknown` rather than `Zero` avoids implying we've confirmed it is always 0 for every variant — we've only observed that shape in the tutorial traces.

## Test plan
- [x] `dotnet test --filter ScriptPacket` passes (both shapes still serialize correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)