### PR TITLE
ci: grant contents:write for release asset upload

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET


### PR DESCRIPTION
Fixes GitHub release creation step which was hitting 'Bad credentials' because GITHUB_TOKEN didn't have write scope under the default-read policy. Sister PRs in NosCore.Shared and NosCore.ParserInputGenerator apply the same fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to properly authorize automated release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->