### PR TITLE
Add PocketType.Mount (9) and Raid (10)

### DIFF
--- a/src/NosCore.Packets/Enumerations/PocketType.cs
+++ b/src/NosCore.Packets/Enumerations/PocketType.cs
@@ -13,6 +13,8 @@ namespace NosCore.Packets.Enumerations
         Etc = 2,
         Miniland = 3,
         Specialist = 6,
-        Costume = 7
+        Costume = 7,
+        Mount = 9,
+        Raid = 10
     }
 }

--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>16.9.0</Version>
+		<Version>16.10.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/test/NosCore.Packets.Tests/SerializerTest.cs
+++ b/test/NosCore.Packets.Tests/SerializerTest.cs
@@ -49,6 +49,7 @@ namespace NosCore.Packets.Tests
                 typeof(SayItemPacket),
                 typeof(MloInfoPacket),
                 typeof(NInvPacket),
+                typeof(InvPacket),
                 typeof(QSlotPacket),
                 typeof(RcbListPacket),
                 typeof(DelayPacket),
@@ -1213,6 +1214,26 @@ namespace NosCore.Packets.Tests
         {
             var p = new SqstPacket { ExtraSpace = string.Empty, Type = 0, Bitmap = "0000" };
             Assert.AreEqual("sqst  0 0000", Serializer.Serialize(p));
+        }
+
+        [TestMethod]
+        [DataRow(PocketType.Mount, (byte)9)]
+        [DataRow(PocketType.Raid, (byte)10)]
+        public void SerializeInvPacketWithExtendedPocketTypesIsValid(PocketType type, byte expectedWireValue)
+        {
+            // Mount=9 and Raid=10 confirmed from official server traces (inv 9 = mount pocket,
+            // inv 10 = raid pocket). Mount/Raid sub-packets use a different shape than Equipment's
+            // IvnSubPacket; here we only assert the enum header value so the protocol-level
+            // mismatch that triggers "Invalid Enum value" on the server is covered.
+            var packet = new InvPacket
+            {
+                Type = type,
+                IvnSubPackets = new List<IvnSubPacket?>()
+            };
+
+            Assert.IsTrue(packet.IsValid, string.Join("; ",
+                packet.ValidationResult.Select(v => $"{string.Join(",", v.MemberNames)}: {v.ErrorMessage}")));
+            Assert.AreEqual($"inv {expectedWireValue} ", Serializer.Serialize(packet));
         }
     }
 }

--- a/test/NosCore.Packets.Tests/SerializerTest.cs
+++ b/test/NosCore.Packets.Tests/SerializerTest.cs
@@ -1221,10 +1221,6 @@ namespace NosCore.Packets.Tests
         [DataRow(PocketType.Raid, (byte)10)]
         public void SerializeInvPacketWithExtendedPocketTypesIsValid(PocketType type, byte expectedWireValue)
         {
-            // Mount=9 and Raid=10 confirmed from official server traces (inv 9 = mount pocket,
-            // inv 10 = raid pocket). Mount/Raid sub-packets use a different shape than Equipment's
-            // IvnSubPacket; here we only assert the enum header value so the protocol-level
-            // mismatch that triggers "Invalid Enum value" on the server is covered.
             var packet = new InvPacket
             {
                 Type = type,


### PR DESCRIPTION
## Summary
Adds the missing `Mount = 9` and `Raid = 10` values to `PocketType`. Confirmed from official-server trace captures where `inv 9 …` is the mount pocket and `inv 10 …` is the raid pocket. Without them NosCore fails validation on every invocation of those two pockets.

## Version
16.9.0 → 16.10.0 (minor bump, additive only).

## Test plan
- [x] `dotnet test` — 108/108 pass
- [x] New parametric `SerializeInvPacketWithExtendedPocketTypesIsValid` asserts `InvPacket.IsValid` is true and the header serializes to `inv 9` / `inv 10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Introduced Mount and Raid pocket types to the packet system, enabling proper categorization and handling of mount and raid-specific inventory items.

**Chores**
- Updated package version to 16.10.0.
- Added validation tests to verify new pocket types serialize and deserialize correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->