### PR TITLE
fix: deserialize list-of-subpackets with pipe/dot SpecialSeparator

### DIFF
--- a/src/NosCore.Packets/Deserializer.cs
+++ b/src/NosCore.Packets/Deserializer.cs
@@ -322,7 +322,13 @@ namespace NosCore.Packets
                 var separator = packetIndexAttribute.SpecialSeparator;
                 if (packetIndexAttribute is PacketListIndexAttribute ind)
                 {
-                    separator = ind.ListSeparator ?? (typeof(IPacket).IsAssignableFrom(subType) ? separator : ".");
+                    // For IPacket (sub-packet) lists, SpecialSeparator on the list names
+                    // the *inner field* separator inside each sub-packet — not the list
+                    // item separator. The list items are tokenised by the outer packet's
+                    // whitespace. Only ListSeparator (when explicitly set) defines how
+                    // items are joined. For primitive lists, SpecialSeparator remains the
+                    // inter-item separator, defaulting to ".".
+                    separator = ind.ListSeparator ?? (typeof(IPacket).IsAssignableFrom(subType) ? null : separator ?? ".");
                 }
                 if (isMaxIndex && string.IsNullOrWhiteSpace(separator))
                 {
@@ -359,9 +365,17 @@ namespace NosCore.Packets
                             var packSeperators = subType.GetProperties()
                                 .Select(prop => prop.GetCustomAttribute<PacketIndexAttribute>()).Where(s => s != null).ToList();
 
+                            // Fall back to the outer list's SpecialSeparator when the next property
+                            // doesn't override it. Sub-packets like ClinitSubPacket don't decorate
+                            // their own properties, so without this fallback the IndexOf looks for
+                            // "." in strings like "5130502|99|68|547|Trippybell" (not present) and
+                            // every loop iteration appends the whole subpacket — producing
+                            // "X|..X|..X|..X|..X|.." that then fails to parse.
+                            var fieldSeparator = packetIndexAttribute.SpecialSeparator ?? ".";
                             for (var index = 0; index < packSeperators.Count; index++)
                             {
-                                var c = index == packSeperators.Count - 1 ? -1 : subpacket.IndexOf(packSeperators[index + 1]!.SpecialSeparator ?? ".", StringComparison.Ordinal);
+                                var isLast = index == packSeperators.Count - 1;
+                                var c = isLast ? -1 : subpacket.IndexOf(packSeperators[index + 1]!.SpecialSeparator ?? fieldSeparator, StringComparison.Ordinal);
                                 if (c == -1)
                                 {
                                     toConvert += subpacket;

--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>17.0.0</Version>
+		<Version>17.1.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/test/NosCore.Packets.Tests/DeserializerTest.cs
+++ b/test/NosCore.Packets.Tests/DeserializerTest.cs
@@ -418,6 +418,35 @@ namespace NosCore.Packets.Tests
         }
 
         [TestMethod]
+        public void PacketWithListOfSubPacketsWithoutPerPropertySeparatorsSplitsCorrectly()
+        {
+            // ClinitPacket is `[PacketListIndex(0, SpecialSeparator = "|")]` over
+            // ClinitSubPacket whose five properties don't decorate their own
+            // SpecialSeparator. Prior to 17.1.0 the list-of-sub-packets path
+            // fell back to "." when looking for each field boundary, which
+            // wasn't present, so the full sub-packet was appended once per
+            // property — yielding "X|..X|..X|..X|..X|.." that then failed to parse.
+            var deserializer = new Deserializer(new[]
+            {
+                typeof(ClinitPacket),
+                typeof(ClinitSubPacket),
+            });
+
+            var packet = (ClinitPacket)deserializer.Deserialize(
+                "clinit 5130502|99|68|547|Trippybell 7170218|99|94|325|Hamu");
+
+            Assert.IsNotNull(packet.SubPackets);
+            Assert.HasCount(2, packet.SubPackets!);
+            Assert.AreEqual(5130502L, packet.SubPackets[0]!.CharacterId);
+            Assert.AreEqual((byte)99, packet.SubPackets[0]!.Level);
+            Assert.AreEqual((byte)68, packet.SubPackets[0]!.HeroLevel);
+            Assert.AreEqual(547, packet.SubPackets[0]!.Compliment);
+            Assert.AreEqual("Trippybell", packet.SubPackets[0]!.CharacterName);
+            Assert.AreEqual(7170218L, packet.SubPackets[1]!.CharacterId);
+            Assert.AreEqual("Hamu", packet.SubPackets[1]!.CharacterName);
+        }
+
+        [TestMethod]
         public void PacketWithEmptySpecialSeparatorSplitsEachCharIntoField()
         {
             // UpgradeRareSubPacket has two fields (Upgrade, Rare). The wire joins


### PR DESCRIPTION
Bumps to **17.1.0** — non-breaking bug fix.

## What's broken

Lists declared like [\`ClinitPacket\`](src/NosCore.Packets/ServerPackets/CharacterSelectionScreen/ClinitPacket.cs):

\`\`\`csharp
[PacketListIndex(0, SpecialSeparator = \"|\")]
public List<ClinitSubPacket?>? SubPackets { get; set; }
\`\`\`

…serialise to \`clinit 14531|94|0|396|Raizen 3011|99|0|346|Thanos\` — list items space-separated, inner fields \`|\`-separated. The **existing serializer test** at [SerializerTest.cs:1102](test/NosCore.Packets.Tests/SerializerTest.cs#L1102) locks this exact shape in. But the **deserializer** couldn't read its own output. Two coupled bugs:

1. [\`Deserializer.cs:325\`](src/NosCore.Packets/Deserializer.cs#L325) picked \`SpecialSeparator\` as the list-**item** separator for IPacket lists, then ran \`matches[currentIndex].Split(\"|\")\` over the first token — turning \`\"5130502|99|68|547|Trippybell\"\` into \`length=5\`. Looping 5 times while the actual list has 30+ items indexed straight off the end of \`matches\`.

2. [\`Deserializer.cs:364\`](src/NosCore.Packets/Deserializer.cs#L364)'s inner field-split loop looked up the next property's \`SpecialSeparator\`, falling back to \`.\` when the sub-packet's properties didn't carry their own separator (the normal case for Clinit/Flinit/Finit/Pinit/etc. style sub-packets). \`.IndexOf(\".\")\` returned -1 and the \`c == -1\` branch appended the whole sub-packet once per property — producing \`\"5130502|99|68|547|Trippybell5130502|99|68|547|Trippybell5130502|99|68|547|Trippybell5130502|99|68|547|Trippybell5130502|99|68|547|Trippybell\"\` that \`long.Parse\` rightly rejected.

## The fix

1. For IPacket lists, ignore \`SpecialSeparator\` as list-item separator — it's the **inner-field** separator. \`ListSeparator\` (when set) still wins. Non-IPacket primitive lists keep the existing \`SpecialSeparator\` / \`.\` behaviour.

2. The inner field-split loop falls back to the outer list's \`SpecialSeparator\` when the sub-packet property doesn't override it.

## What this unblocks

Inbound round-trip for any list-of-subpackets where inner fields share a separator: \`clinit\`, \`flinit\`, \`kdlinit\`, \`skyinit\`, \`finit\`, \`pinit\`, \`blinit\`, \`rcblist\`, \`rcslist\`, \`ninv\`, \`mlobjlst\`, \`tarank\`, plus anything new.

## Test plan
- [x] \`dotnet test\` — 113 / 113 pass, including the new regression test round-tripping a two-entry ClinitPacket.
- [x] Existing serializer round-trip test for ClinitPacket still passes (serializer output unchanged — only deserializer behaviour changed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed packet list deserialization to properly handle nested sub-packets with custom separators. Corrected boundary detection during token parsing that previously caused incomplete sub-packet processing.

* **Tests**
  * Added test coverage for complex packet list deserialization scenarios with special separators and nested sub-packets without individual property separators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->