### PR TITLE
fix: stop appending tail when sub-packet has fewer fields than schema

### DIFF
--- a/src/NosCore.Packets/Deserializer.cs
+++ b/src/NosCore.Packets/Deserializer.cs
@@ -378,13 +378,18 @@ namespace NosCore.Packets
                                 var c = isLast ? -1 : subpacket.IndexOf(packSeperators[index + 1]!.SpecialSeparator ?? fieldSeparator, StringComparison.Ordinal);
                                 if (c == -1)
                                 {
+                                    // Wire item has fewer fields than the sub-packet schema (common
+                                    // for optional trailing fields — e.g. IvnSubPacket has 7 indexes
+                                    // but `inv 1 0.5110.1` carries only 3). Emit the remaining
+                                    // subpacket once and stop; without this break the same tail got
+                                    // appended once per remaining schema property — producing
+                                    // "1 9023 33333" that overflowed Int16 or hit index-out-of-bounds.
                                     toConvert += subpacket;
+                                    break;
                                 }
-                                else
-                                {
-                                    toConvert += subpacket.Substring(0, c) + " ";
-                                    subpacket = subpacket.Substring(c + 1);
-                                }
+
+                                toConvert += subpacket.Substring(0, c) + " ";
+                                subpacket = subpacket.Substring(c + 1);
                             }
                         }
                         else

--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>17.1.0</Version>
+		<Version>17.2.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/test/NosCore.Packets.Tests/DeserializerTest.cs
+++ b/test/NosCore.Packets.Tests/DeserializerTest.cs
@@ -447,6 +447,33 @@ namespace NosCore.Packets.Tests
         }
 
         [TestMethod]
+        public void PacketWithSubPacketShorterThanSchemaLeavesTrailingFieldsDefault()
+        {
+            // IvnSubPacket has seven [PacketIndex] properties, but `inv 1` packets
+            // only carry `<slot>.<vnum>.<amount>` (three tokens). Prior to 17.2.0
+            // the inner field-split loop kept iterating seven times — once the
+            // separator was exhausted it appended the tail onto every remaining
+            // iteration, producing "1 9023 33333" that overflowed RareAmount
+            // (short). Break on first exhausted separator.
+            var deserializer = new Deserializer(new[]
+            {
+                typeof(ServerPackets.Inventory.InvPacket),
+                typeof(ServerPackets.Inventory.IvnSubPacket),
+            });
+
+            var packet = (ServerPackets.Inventory.InvPacket)deserializer.Deserialize("inv 1 0.5110.1 1.9023.3");
+
+            Assert.IsNotNull(packet.IvnSubPackets);
+            Assert.HasCount(2, packet.IvnSubPackets!);
+            Assert.AreEqual((short)0, packet.IvnSubPackets[0].Slot);
+            Assert.AreEqual((short)5110, packet.IvnSubPackets[0].VNum);
+            Assert.AreEqual((short)1, packet.IvnSubPackets[0].RareAmount);
+            Assert.AreEqual((short)1, packet.IvnSubPackets[1].Slot);
+            Assert.AreEqual((short)9023, packet.IvnSubPackets[1].VNum);
+            Assert.AreEqual((short)3, packet.IvnSubPackets[1].RareAmount);
+        }
+
+        [TestMethod]
         public void PacketWithEmptySpecialSeparatorSplitsEachCharIntoField()
         {
             // UpgradeRareSubPacket has two fields (Upgrade, Rare). The wire joins


### PR DESCRIPTION
Bumps to **17.2.0**, non-breaking bug fix.

Single-line change in the inner field-split loop plus an early-exit. The loop was iterating for every property of the schema, appending the remaining subpacket on every iteration once the separator was exhausted — producing values like `"1 9023 33333"` from `"1.9023.3"` against a 7-field schema, which then failed with Int16 overflow, index-out-of-bounds, or format errors depending on the field type.

Resolves observed failures on `inv` / `sayi` / `msgi` / `msgi2` / `mlobjlst` / `infoi` / `qslot` / `fish` / `qstlist` / `pinit`.

## Test plan
- [x] 114/114 green
- [x] New regression test round-trips `inv 1 0.5110.1 1.9023.3` against the seven-field `IvnSubPacket` and asserts the trailing fields default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a deserialization issue where sub-packet list processing would incorrectly continue when wire tokens contained fewer fields than the schema expects, preventing potential data corruption during packet parsing.

* **Chores**
  * Package version updated to 17.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->