### PR TITLE
fix: TwkPacket setters + PetskiPacket schema + add QnamliPacket (17.3.0)

### DIFF
--- a/documentation/DocumentationTest.PacketsDocumentation.verified.md
+++ b/documentation/DocumentationTest.PacketsDocumentation.verified.md
@@ -422,6 +422,7 @@
 - [gp](../src/NosCore.Packets/ServerPackets/Portals/GpPacket.cs) *InGame*
 
 ### Quest
+- [qnamli](../src/NosCore.Packets/ServerPackets/Quest/QnamliPacket.cs) *InGame*
 - [qr](../src/NosCore.Packets/ServerPackets/Quest/QrPacket.cs) *InGame*
 - [qsti](../src/NosCore.Packets/ServerPackets/Quest/QstiPacket.cs) *InGame*
 - [qstlist](../src/NosCore.Packets/ServerPackets/Quest/QstlistPacket.cs) *InGame*

--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>17.2.0</Version>
+		<Version>17.3.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Packets/ServerPackets/Mates/PetskiPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Mates/PetskiPacket.cs
@@ -7,6 +7,12 @@ namespace NosCore.Packets.ServerPackets.Mates
     public class PetskiPacket : PacketBase
     {
         [PacketIndex(0)]
-        public sbyte MateTransportId { get; set; }
+        public int MateTransportId { get; set; }
+
+        [PacketIndex(1)]
+        public short FirstSkillVNum { get; set; }
+
+        [PacketIndex(2)]
+        public short SecondSkillVNum { get; set; }
     }
 }

--- a/src/NosCore.Packets/ServerPackets/Quest/QnamliPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Quest/QnamliPacket.cs
@@ -1,0 +1,38 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using NosCore.Packets.Attributes;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.Packets.ServerPackets.Quest
+{
+    /// <summary>
+    /// Server-side quest name list entry. Shape observed on the wire:
+    /// <c>qnamli &lt;questId&gt; #&lt;localizedRef&gt; &lt;targetId&gt; &lt;value1&gt; &lt;value2&gt; &lt;value3&gt;</c>
+    /// e.g. <c>qnamli 9 #guri^518 2308 0 0 0</c>.
+    /// </summary>
+    [PacketHeader("qnamli", Scope.InGame)]
+    public class QnamliPacket : PacketBase
+    {
+        [PacketIndex(0)]
+        public int QuestId { get; set; }
+
+        [PacketIndex(1, RemoveHash = true)]
+        public string? Guri { get; set; }
+
+        [PacketIndex(2)]
+        public int TargetId { get; set; }
+
+        [PacketIndex(3)]
+        public int Value1 { get; set; }
+
+        [PacketIndex(4)]
+        public int Value2 { get; set; }
+
+        [PacketIndex(5)]
+        public int Value3 { get; set; }
+    }
+}

--- a/src/NosCore.Packets/ServerPackets/UI/TwkPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/UI/TwkPacket.cs
@@ -33,14 +33,14 @@ namespace NosCore.Packets.ServerPackets.UI
         public string ClientLanguageString
         {
             get => ClientLanguage.ToString().ToLowerInvariant();
-            set => throw new ArgumentException("do not set this set the ClientLanguage instead");
+            set => ClientLanguage = Enum.Parse<RegionType>(value, ignoreCase: true);
         }
 
         [PacketIndex(6)]
         public string ServerLanguageString
         {
             get => ServerLanguage.ToString().ToLowerInvariant();
-            set => throw new ArgumentException("do not set this set the ServerLanguage instead");
+            set => ServerLanguage = Enum.Parse<RegionType>(value, ignoreCase: true);
         }
 
         public RegionType ServerLanguage { get; set; }

--- a/test/NosCore.Packets.Tests/SerializerTest.cs
+++ b/test/NosCore.Packets.Tests/SerializerTest.cs
@@ -1011,7 +1011,14 @@ namespace NosCore.Packets.Tests
         [TestMethod]
         public void SerializePetskiPacketMatchesTrace()
         {
-            Assert.AreEqual("petski -2", Serializer.Serialize(new PetskiPacket { MateTransportId = -2 }));
+            Assert.AreEqual(
+                "petski 790 -1 -1",
+                Serializer.Serialize(new PetskiPacket
+                {
+                    MateTransportId = 790,
+                    FirstSkillVNum = -1,
+                    SecondSkillVNum = -1,
+                }));
         }
 
         [TestMethod]


### PR DESCRIPTION
Targeted schema fixes surfaced by the validator. Non-breaking except for TwkPacket — consumers relying on the old 'throw on set' invariant won't see it anymore; net effect is that deserialization now actually works.

- **TwkPacket**: setters parse the RegionType enum instead of throwing, fixing 'Exception has been thrown by the target of an invocation.'
- **PetskiPacket**: widen MateTransportId to int (was sbyte — overflowed on 790), add missing FirstSkillVNum / SecondSkillVNum (short). Matches real wire `petski <id> <s1> <s2>`.
- **QnamliPacket** (new): unblocks 'qnamli' showing up as Missing.

Tests: 114/114. Petski serializer test updated to lock in the three-field shape; documentation snapshot updated to include the new QnamliPacket entry.