### PR TITLE
feat: direction-pair packets (gidx/npc_req/rsfi server, mall/npinfo client) — 17.4.0

### DIFF
--- a/documentation/DocumentationTest.PacketsDocumentation.verified.md
+++ b/documentation/DocumentationTest.PacketsDocumentation.verified.md
@@ -167,6 +167,7 @@
 - [bpt](../src/NosCore.Packets/ClientPackets/Player/BptPacket.cs) *InGame*
 - [compl](../src/NosCore.Packets/ClientPackets/Player/ComplPacket.cs) *InGame*
 - [eqinfo](../src/NosCore.Packets/ClientPackets/Player/EquipmentInfoPacket.cs) *InGame*
+- [npinfo](../src/NosCore.Packets/ClientPackets/Player/NpInfoPacket.cs) *InGame*
 - [rsfi](../src/NosCore.Packets/ClientPackets/Player/RsfiPacket.cs) *InGame*
 - [snap](../src/NosCore.Packets/ClientPackets/Player/SnapPacket.cs) *InTrade | InGame*
 - [tit_eq](../src/NosCore.Packets/ClientPackets/Player/TitEqPacket.cs) *InTrade | InGame*
@@ -205,6 +206,7 @@
 ### UI
 - [gop](../src/NosCore.Packets/ClientPackets/UI/GopPacket.cs) *InGame*
 - [guri](../src/NosCore.Packets/ClientPackets/UI/GuriPacket.cs) *InGame*
+- [mall](../src/NosCore.Packets/ClientPackets/UI/MallPacket.cs) *InGame*
 
 ### Warehouse
 - [deposit](../src/NosCore.Packets/ClientPackets/Warehouse/DepositPacket.cs) *InTrade | InGame*
@@ -310,6 +312,7 @@
 ### Families
 - [fc](../src/NosCore.Packets/ServerPackets/Families/FcPacket.cs) *InGame*
 - [fslog_stc](../src/NosCore.Packets/ServerPackets/Families/FslogStcPacket.cs) *InGame*
+- [gidx](../src/NosCore.Packets/ServerPackets/Families/GidxPacket.cs) *InTrade | InGame*
 - [ginfo](../src/NosCore.Packets/ServerPackets/Families/GInfoPacket.cs) *InGame*
 
 ### Groups
@@ -383,6 +386,9 @@
 ### Movement
 - [dir](../src/NosCore.Packets/ServerPackets/Movement/DirPacket.cs) *InGame*
 
+### Npcs
+- [npc_req](../src/NosCore.Packets/ServerPackets/Npcs/NpcReqPacket.cs) *InGame*
+
 ### Parcel
 - [parcel](../src/NosCore.Packets/ServerPackets/Parcel/ParcelPacket.cs) *InGame*
 - [post](../src/NosCore.Packets/ServerPackets/Parcel/PostPacket.cs) *InGame*
@@ -405,6 +411,7 @@
 - [npinfo](../src/NosCore.Packets/ServerPackets/Player/NpInfoPacket.cs) *InGame*
 - [p_sex](../src/NosCore.Packets/ServerPackets/Player/PSexPacket.cs) *InGame*
 - [rage](../src/NosCore.Packets/ServerPackets/Player/RagePacket.cs) *InGame*
+- [rsfi](../src/NosCore.Packets/ServerPackets/Player/RsfiPacket.cs) *InGame*
 - [sc](../src/NosCore.Packets/ServerPackets/Player/ScPacket.cs) *InGame*
 - [scr](../src/NosCore.Packets/ServerPackets/Player/ScrPacket.cs) *InGame*
 - [ski](../src/NosCore.Packets/ServerPackets/Player/SkiPacket.cs) *InGame*

--- a/src/NosCore.Packets/ClientPackets/Player/NpInfoPacket.cs
+++ b/src/NosCore.Packets/ClientPackets/Player/NpInfoPacket.cs
@@ -1,0 +1,22 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using NosCore.Packets.Attributes;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.Packets.ClientPackets.Player
+{
+    /// <summary>
+    /// Client-side request for the "new player info" page, e.g. <c>npinfo 0</c>.
+    /// Mirrors the server-side <see cref="NosCore.Packets.ServerPackets.Player.NpInfoPacket"/>.
+    /// </summary>
+    [PacketHeader("npinfo", Scope.InGame)]
+    public class NpInfoPacket : PacketBase
+    {
+        [PacketIndex(0)]
+        public byte Page { get; set; }
+    }
+}

--- a/src/NosCore.Packets/ClientPackets/UI/MallPacket.cs
+++ b/src/NosCore.Packets/ClientPackets/UI/MallPacket.cs
@@ -1,0 +1,22 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using NosCore.Packets.Attributes;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.Packets.ClientPackets.UI
+{
+    /// <summary>
+    /// Client-side request to open the in-game mall UI, e.g. <c>mall 50</c>.
+    /// Mirrors the server-side <see cref="NosCore.Packets.ServerPackets.UI.MallPacket"/>.
+    /// </summary>
+    [PacketHeader("mall", Scope.InGame)]
+    public class MallPacket : PacketBase
+    {
+        [PacketIndex(0)]
+        public byte State { get; set; }
+    }
+}

--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>17.3.0</Version>
+		<Version>17.4.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Packets/ServerPackets/Families/GidxFamilySubPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Families/GidxFamilySubPacket.cs
@@ -1,0 +1,25 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using NosCore.Packets.Attributes;
+
+namespace NosCore.Packets.ServerPackets.Families
+{
+    /// <summary>
+    /// Server-side family identifier sub-packet used by <see cref="GidxPacket"/>:
+    /// <c>&lt;serverId&gt;.&lt;familyId&gt;</c>, e.g. <c>103.918</c>.
+    /// When the character has no family the whole field collapses to <c>-1</c>
+    /// on the wire, leaving <see cref="FamilyId"/> at its default value.
+    /// </summary>
+    public class GidxFamilySubPacket : PacketBase
+    {
+        [PacketIndex(0)]
+        public int ServerId { get; set; }
+
+        [PacketIndex(1)]
+        public long FamilyId { get; set; }
+    }
+}

--- a/src/NosCore.Packets/ServerPackets/Families/GidxPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Families/GidxPacket.cs
@@ -1,0 +1,40 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using System.Collections.Generic;
+using NosCore.Packets.Attributes;
+using NosCore.Packets.Enumerations;
+using NosCore.Shared.Enumerations;
+
+namespace NosCore.Packets.ServerPackets.Families
+{
+    /// <summary>
+    /// Server-side family indicator packet, observed as e.g.
+    /// <c>gidx 1 5739 103.918 LastDemons 9 0|0|0</c> or
+    /// <c>gidx 1 14293841 -1 - 0 0|0|0</c> when there is no family.
+    /// </summary>
+    [PacketHeader("gidx", Scope.InGame | Scope.InTrade)]
+    public class GidxPacket : PacketBase
+    {
+        [PacketIndex(0)]
+        public VisualType VisualType { get; set; }
+
+        [PacketIndex(1)]
+        public long VisualId { get; set; }
+
+        [PacketIndex(2, SpecialSeparator = ".")]
+        public GidxFamilySubPacket? FamilyIdentifier { get; set; }
+
+        [PacketIndex(3)]
+        public string? FamilyName { get; set; }
+
+        [PacketIndex(4)]
+        public byte FamilyLevel { get; set; }
+
+        [PacketListIndex(5, ListSeparator = "|")]
+        public List<bool> FamilyIcons { get; set; } = new();
+    }
+}

--- a/src/NosCore.Packets/ServerPackets/Npcs/NpcReqPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Npcs/NpcReqPacket.cs
@@ -1,0 +1,29 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using NosCore.Packets.Attributes;
+using NosCore.Packets.Enumerations;
+using NosCore.Shared.Enumerations;
+
+namespace NosCore.Packets.ServerPackets.Npcs
+{
+    /// <summary>
+    /// Server-side NPC request packet, observed as e.g. <c>npc_req 2 5140 16</c>.
+    /// Mirrors the client-side <see cref="NosCore.Packets.ClientPackets.Npcs.RequestNpcPacket"/>.
+    /// </summary>
+    [PacketHeader("npc_req", Scope.InGame)]
+    public class NpcReqPacket : PacketBase
+    {
+        [PacketIndex(0)]
+        public VisualType Type { get; set; }
+
+        [PacketIndex(1)]
+        public long TargetId { get; set; }
+
+        [PacketIndex(2)]
+        public long? Data { get; set; }
+    }
+}

--- a/src/NosCore.Packets/ServerPackets/Player/RsfiPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Player/RsfiPacket.cs
@@ -1,0 +1,38 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using NosCore.Packets.Attributes;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.Packets.ServerPackets.Player
+{
+    /// <summary>
+    /// Server-side timespace progression packet, observed as e.g.
+    /// <c>rsfi 3 3 0 1 0 1</c>. Mirrors the client-side
+    /// <see cref="NosCore.Packets.ClientPackets.Player.RsfiPacket"/>.
+    /// </summary>
+    [PacketHeader("rsfi", Scope.InGame)]
+    public class RsfiPacket : PacketBase
+    {
+        [PacketIndex(0)]
+        public byte Act { get; set; }
+
+        [PacketIndex(1)]
+        public byte ActPart { get; set; }
+
+        [PacketIndex(2)]
+        public byte Unknown1 { get; set; }
+
+        [PacketIndex(3)]
+        public byte Unknown2 { get; set; }
+
+        [PacketIndex(4)]
+        public byte Ts { get; set; }
+
+        [PacketIndex(5)]
+        public byte TsMax { get; set; }
+    }
+}


### PR DESCRIPTION
Adds the opposite-side classes for headers the validator was flagging as Wrong tag.

Concrete set added: `ServerPackets.Families.GidxPacket` (+ sub-packet), `ServerPackets.Npcs.NpcReqPacket`, `ServerPackets.Player.RsfiPacket`, `ClientPackets.UI.MallPacket`, `ClientPackets.Player.NpInfoPacket`.

Deferred (need real RE work, not safe to guess): `bpm`/`bpt` server-side.

- [x] 114/114 tests