### PR TITLE
feat: add Qnamli2Packet and ServerPackets.Player.BpmPacket (17.5.0)

### DIFF
--- a/documentation/DocumentationTest.PacketsDocumentation.verified.md
+++ b/documentation/DocumentationTest.PacketsDocumentation.verified.md
@@ -396,6 +396,7 @@
 
 ### Player
 - [bn](../src/NosCore.Packets/ServerPackets/Player/BnPacket.cs) *InGame*
+- [bpm](../src/NosCore.Packets/ServerPackets/Player/BpmPacket.cs) *InGame*
 - [c_info](../src/NosCore.Packets/ServerPackets/Player/CInfoPacket.cs) *InGame*
 - [c_info_reset](../src/NosCore.Packets/ServerPackets/Player/CInfoResetPacket.cs) *InGame*
 - [c_mode](../src/NosCore.Packets/ServerPackets/Player/CModePacket.cs) *InGame*
@@ -429,6 +430,7 @@
 - [gp](../src/NosCore.Packets/ServerPackets/Portals/GpPacket.cs) *InGame*
 
 ### Quest
+- [qnamli2](../src/NosCore.Packets/ServerPackets/Quest/Qnamli2Packet.cs) *InGame*
 - [qnamli](../src/NosCore.Packets/ServerPackets/Quest/QnamliPacket.cs) *InGame*
 - [qr](../src/NosCore.Packets/ServerPackets/Quest/QrPacket.cs) *InGame*
 - [qsti](../src/NosCore.Packets/ServerPackets/Quest/QstiPacket.cs) *InGame*

--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>17.4.0</Version>
+		<Version>17.5.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Packets/ServerPackets/Player/BpmPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Player/BpmPacket.cs
@@ -1,0 +1,30 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using NosCore.Packets.Attributes;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.Packets.ServerPackets.Player
+{
+    /// <summary>
+    /// Server-side compact battle-pass marker, observed as <c>bpm 0 0 0</c>
+    /// (three bytes). Distinct from the large
+    /// <see cref="NosCore.Packets.ClientPackets.Player.BpmPacket"/> request that
+    /// carries the full quest list.
+    /// </summary>
+    [PacketHeader("bpm", Scope.InGame)]
+    public class BpmPacket : PacketBase
+    {
+        [PacketIndex(0)]
+        public byte State { get; set; }
+
+        [PacketIndex(1)]
+        public byte Unknown1 { get; set; }
+
+        [PacketIndex(2)]
+        public byte Unknown2 { get; set; }
+    }
+}

--- a/src/NosCore.Packets/ServerPackets/Quest/Qnamli2Packet.cs
+++ b/src/NosCore.Packets/ServerPackets/Quest/Qnamli2Packet.cs
@@ -1,0 +1,38 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using NosCore.Packets.Attributes;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.Packets.ServerPackets.Quest
+{
+    /// <summary>
+    /// Server-side variant of <see cref="QnamliPacket"/> with a trailing
+    /// character/target name. Observed wire:
+    /// <c>qnamli2 100 #rl 1646 13 2514 Gladi</c>.
+    /// </summary>
+    [PacketHeader("qnamli2", Scope.InGame)]
+    public class Qnamli2Packet : PacketBase
+    {
+        [PacketIndex(0)]
+        public int QuestId { get; set; }
+
+        [PacketIndex(1, RemoveHash = true)]
+        public string? Guri { get; set; }
+
+        [PacketIndex(2)]
+        public int TargetId { get; set; }
+
+        [PacketIndex(3)]
+        public int Value1 { get; set; }
+
+        [PacketIndex(4)]
+        public int Value2 { get; set; }
+
+        [PacketIndex(5)]
+        public string? TargetName { get; set; }
+    }
+}


### PR DESCRIPTION
Two missing schemas that were flagged by the validator:
- `Qnamli2Packet` — matches `qnamli2 100 #rl 1646 13 2514 Gladi`.
- `ServerPackets.Player.BpmPacket` — matches the compact `bpm 0 0 0` server form, distinct from the existing client-side request packet.

Packets directory placement confirmed: all ClientPackets.* live under src/NosCore.Packets/ClientPackets/ and all ServerPackets.* under src/NosCore.Packets/ServerPackets/ (scanned tree, no mismatches).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for two new in-game server packet types, expanding protocol communication capabilities.

* **Documentation**
  * Updated ServerPackets documentation to reflect newly supported packet formats.

* **Chores**
  * Incremented package version to 17.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->