### PR TITLE
fix: Game18NArguments, SayItemtPacket, PinitSubPacket, RcPacket (17.6.0)

### DIFF
--- a/documentation/DocumentationTest.PacketsDocumentation.verified.md
+++ b/documentation/DocumentationTest.PacketsDocumentation.verified.md
@@ -412,6 +412,7 @@
 - [npinfo](../src/NosCore.Packets/ServerPackets/Player/NpInfoPacket.cs) *InGame*
 - [p_sex](../src/NosCore.Packets/ServerPackets/Player/PSexPacket.cs) *InGame*
 - [rage](../src/NosCore.Packets/ServerPackets/Player/RagePacket.cs) *InGame*
+- [rc](../src/NosCore.Packets/ServerPackets/Player/RcPacket.cs) *InGame*
 - [rsfi](../src/NosCore.Packets/ServerPackets/Player/RsfiPacket.cs) *InGame*
 - [sc](../src/NosCore.Packets/ServerPackets/Player/ScPacket.cs) *InGame*
 - [scr](../src/NosCore.Packets/ServerPackets/Player/ScrPacket.cs) *InGame*

--- a/src/NosCore.Packets/Deserializer.cs
+++ b/src/NosCore.Packets/Deserializer.cs
@@ -284,6 +284,20 @@ namespace NosCore.Packets
                 case var prop when (prop.BaseType?.Equals(typeof(Enum)) ?? false) ||
                     (Nullable.GetUnderlyingType(prop)?.IsEnum ?? false):
                     return DeserializeEnum(item1, matches[currentIndex++]);
+                case var prop when prop == typeof(Game18NArguments):
+                    // Game18NArguments is a custom non-generic IList<object>. The generic
+                    // list path can't figure out its element type (GetGenericArguments() is
+                    // empty) and can't assign List<object> to it, so sayi/msgi/msgi2 all
+                    // crashed with IndexOutOfRange. Consume the remaining tokens directly
+                    // into a fresh Game18NArguments; numeric tokens go in as long, the rest
+                    // as string.
+                    var g18n = new Game18NArguments(Math.Max(1, matches.Length - currentIndex));
+                    while (currentIndex < matches.Length)
+                    {
+                        var token = matches[currentIndex++];
+                        g18n.Add(long.TryParse(token, out var longValue) ? (object)longValue : token);
+                    }
+                    return g18n;
                 case var prop when typeof(ICollection).IsAssignableFrom(prop):
                     return DeserializeList(packetBasePropertyInfo.Item1.GetElementType() ?? packetBasePropertyInfo.Item1.GetGenericArguments()[0], packetBasePropertyInfo.Item2, matches, ref currentIndex, isMaxIndex);
                 case var prop when prop == typeof(IPacket):

--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>17.5.0</Version>
+		<Version>17.6.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Packets/ServerPackets/Chats/SayItemtPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Chats/SayItemtPacket.cs
@@ -1,4 +1,4 @@
-﻿//  __  _  __    __   ___ __  ___ ___
+//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -6,11 +6,19 @@
 
 using NosCore.Packets.Attributes;
 using NosCore.Packets.Enumerations;
-using NosCore.Packets.ServerPackets.Inventory;
 using NosCore.Shared.Enumerations;
 
 namespace NosCore.Packets.ServerPackets.Chats
 {
+    /// <summary>
+    /// Chat bubble advertising a specific item/character, observed on the wire as:
+    /// <c>sayitemt 1 &lt;visualId&gt; &lt;oratorSlot&gt; &lt;type&gt; &lt;messageKey&gt; &lt;visualName&gt; &lt;argument&gt; &lt;subPacket...&gt;</c>
+    /// where <c>subPacket</c> is one of <c>IconInfo …</c>, <c>e_info …</c>,
+    /// <c>slinfo …</c> or <c>pslinfo …</c>. Because only one sub-packet shape
+    /// appears per wire line and the dispatch depends on the header token,
+    /// the whole tail is captured as a single raw string — consumers that need
+    /// structure should deserialise <see cref="SubPacketRaw"/> separately.
+    /// </summary>
     [PacketHeader("sayitemt", Scope.InGame)]
     public class SayItemtPacket : PacketBase
     {
@@ -29,20 +37,13 @@ namespace NosCore.Packets.ServerPackets.Chats
         [PacketIndex(4)]
         public Game18NConstString Message { get; set; }
 
-        [PacketIndex(4)]
+        [PacketIndex(5)]
         public string? VisualName { get; set; }
 
-        [PacketIndex(3, IsOptional = true)]
+        [PacketIndex(6, IsOptional = true)]
         public string? Argument { get; set; } = "{%s}";
 
-        [PacketIndex(4, IsOptional = true, RemoveHash = true)]
-        public IconInfoPacket? IconInfo { get; set; }
-
-        [PacketIndex(5, IsOptional = true, RemoveHash = true)]
-        public EInfoPacket? EquipmentInfo { get; set; }
-
-        [PacketIndex(6, IsOptional = true, RemoveHash = true)]
-        public SlInfoPacket? SlInfo { get; set; }
-
+        [PacketIndex(7, IsOptional = true)]
+        public string? SubPacketRaw { get; set; }
     }
 }

--- a/src/NosCore.Packets/ServerPackets/Groups/PinitSubPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Groups/PinitSubPacket.cs
@@ -34,15 +34,18 @@ namespace NosCore.Packets.ServerPackets.Groups
         public int Unknown { get; set; } //TODO: Find what this is made for
 
         [PacketIndex(6)]
-        public GenderType Gender { get; set; }
+        public int Unknown2 { get; set; } //TODO: Find what this is made for. Observed 319 on live wire, shifts Gender/Race/Morph/HeroLevel by one.
 
         [PacketIndex(7)]
-        public short Race { get; set; }
+        public GenderType Gender { get; set; }
 
         [PacketIndex(8)]
-        public short Morph { get; set; }
+        public short Race { get; set; }
 
         [PacketIndex(9)]
+        public short Morph { get; set; }
+
+        [PacketIndex(10)]
         public byte HeroLevel { get; set; }
     }
 }

--- a/src/NosCore.Packets/ServerPackets/Player/RcPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Player/RcPacket.cs
@@ -1,0 +1,31 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using NosCore.Packets.Attributes;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.Packets.ServerPackets.Player
+{
+    /// <summary>
+    /// Server-side compact packet observed as <c>rc 1 14477871 11468 0</c>.
+    /// Fields are unnamed until the semantics are reverse-engineered.
+    /// </summary>
+    [PacketHeader("rc", Scope.InGame)]
+    public class RcPacket : PacketBase
+    {
+        [PacketIndex(0)]
+        public byte Type { get; set; }
+
+        [PacketIndex(1)]
+        public long VisualId { get; set; }
+
+        [PacketIndex(2)]
+        public int Unknown1 { get; set; }
+
+        [PacketIndex(3)]
+        public int Unknown2 { get; set; }
+    }
+}


### PR DESCRIPTION
Batch of fixes the validator surfaced.

- **Game18NArguments** special-case in DeserializeValue — unlocks sayi / msgi / msgi2 at once.
- **SayItemtPacket** — four props sharing PacketIndex(3) and PacketIndex(4) caused the character name to be parsed as a Game18NConstString enum. Flattened to sequential indices; typed sub-packet variants replaced with a string SubPacketRaw catch-all (sub-packet polymorphism is a separate task).
- **PinitSubPacket** — inserted Unknown2 (int) at index 6 to accommodate the 11-field wire that previously overflowed byte Gender.
- **RcPacket** — new class for the `rc` header.

114/114 tests.