### PR TITLE
feat!: 20.0.0 - CMapPacket.IsEntering rename, add gmsg/gexp/rsfn/minfo/fbs

### DIFF
--- a/documentation/DocumentationTest.PacketsDocumentation.verified.md
+++ b/documentation/DocumentationTest.PacketsDocumentation.verified.md
@@ -312,8 +312,10 @@
 ### Families
 - [fc](../src/NosCore.Packets/ServerPackets/Families/FcPacket.cs) *InGame*
 - [fslog_stc](../src/NosCore.Packets/ServerPackets/Families/FslogStcPacket.cs) *InGame*
+- [gexp](../src/NosCore.Packets/ServerPackets/Families/GexpPacket.cs) *InGame*
 - [gidx](../src/NosCore.Packets/ServerPackets/Families/GidxPacket.cs) *InTrade | InGame*
 - [ginfo](../src/NosCore.Packets/ServerPackets/Families/GInfoPacket.cs) *InGame*
+- [gmsg](../src/NosCore.Packets/ServerPackets/Families/GmsgPacket.cs) *InGame*
 
 ### Groups
 - [ftpt](../src/NosCore.Packets/ServerPackets/Groups/FtptPacket.cs) *InGame*
@@ -445,6 +447,9 @@
 - [qset](../src/NosCore.Packets/ServerPackets/Quicklist/QsetClientPacket.cs) *InGame*
 - [qslot](../src/NosCore.Packets/ServerPackets/Quicklist/QSlotPacket.cs) *InGame*
 
+### RainbowBattle
+- [fbs](../src/NosCore.Packets/ServerPackets/RainbowBattle/FbsPacket.cs) *InGame*
+
 ### Relations
 - [blinit](../src/NosCore.Packets/ServerPackets/Relations/BlinitPacket.cs) *InGame*
 - [finfo](../src/NosCore.Packets/ServerPackets/Relations/FinfoPacket.cs) *InGame*
@@ -471,6 +476,10 @@
 - [sc_p_stc](../src/NosCore.Packets/ServerPackets/Specialists/ScPStcPacket.cs) *InGame*
 - [sd](../src/NosCore.Packets/ServerPackets/Specialists/SdPacket.cs) *InGame*
 - [sp](../src/NosCore.Packets/ServerPackets/Specialists/SpPacket.cs) *InGame*
+
+### TimeSpaces
+- [minfo](../src/NosCore.Packets/ServerPackets/TimeSpaces/MinfoPacket.cs) *InGame*
+- [rsfn](../src/NosCore.Packets/ServerPackets/TimeSpaces/RsfnPacket.cs) *InGame*
 
 ### UI
 - [act6](../src/NosCore.Packets/ServerPackets/UI/Act6Packet.cs) *InGame*

--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>19.0.0</Version>
+		<Version>20.0.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Packets/ServerPackets/Families/GexpPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Families/GexpPacket.cs
@@ -1,0 +1,19 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using System.Collections.Generic;
+using NosCore.Packets.Attributes;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.Packets.ServerPackets.Families
+{
+    [PacketHeader("gexp", Scope.InGame)]
+    public class GexpPacket : PacketBase
+    {
+        [PacketListIndex(0)]
+        public List<GexpSubPacket?>? Entries { get; set; }
+    }
+}

--- a/src/NosCore.Packets/ServerPackets/Families/GexpSubPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Families/GexpSubPacket.cs
@@ -1,0 +1,19 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using NosCore.Packets.Attributes;
+
+namespace NosCore.Packets.ServerPackets.Families
+{
+    public class GexpSubPacket : PacketBase
+    {
+        [PacketIndex(0)]
+        public long CharacterId { get; set; }
+
+        [PacketIndex(1, SpecialSeparator = "|")]
+        public long Experience { get; set; }
+    }
+}

--- a/src/NosCore.Packets/ServerPackets/Families/GmsgPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Families/GmsgPacket.cs
@@ -1,0 +1,19 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using System.Collections.Generic;
+using NosCore.Packets.Attributes;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.Packets.ServerPackets.Families
+{
+    [PacketHeader("gmsg", Scope.InGame)]
+    public class GmsgPacket : PacketBase
+    {
+        [PacketListIndex(0)]
+        public List<GmsgSubPacket?>? Entries { get; set; }
+    }
+}

--- a/src/NosCore.Packets/ServerPackets/Families/GmsgSubPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Families/GmsgSubPacket.cs
@@ -1,0 +1,19 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using NosCore.Packets.Attributes;
+
+namespace NosCore.Packets.ServerPackets.Families
+{
+    public class GmsgSubPacket : PacketBase
+    {
+        [PacketIndex(0)]
+        public long CharacterId { get; set; }
+
+        [PacketIndex(1, SpecialSeparator = "|")]
+        public string? Message { get; set; }
+    }
+}

--- a/src/NosCore.Packets/ServerPackets/RainbowBattle/FbsPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/RainbowBattle/FbsPacket.cs
@@ -1,0 +1,39 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using NosCore.Packets.Attributes;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.Packets.ServerPackets.RainbowBattle
+{
+    [PacketHeader("fbs", Scope.InGame)]
+    public class FbsPacket : PacketBase
+    {
+        [PacketIndex(0)]
+        public byte TeamId { get; set; }
+
+        [PacketIndex(1)]
+        public int TeamCount { get; set; }
+
+        [PacketIndex(2)]
+        public int RedPoints { get; set; }
+
+        [PacketIndex(3)]
+        public int BluePoints { get; set; }
+
+        [PacketIndex(4)]
+        public int SmallFlags { get; set; }
+
+        [PacketIndex(5)]
+        public int MediumFlags { get; set; }
+
+        [PacketIndex(6)]
+        public int BigFlags { get; set; }
+
+        [PacketIndex(7)]
+        public string? TeamName { get; set; }
+    }
+}

--- a/src/NosCore.Packets/ServerPackets/TimeSpaces/MinfoConversationSubPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/TimeSpaces/MinfoConversationSubPacket.cs
@@ -1,0 +1,19 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using NosCore.Packets.Attributes;
+
+namespace NosCore.Packets.ServerPackets.TimeSpaces
+{
+    public class MinfoConversationSubPacket : PacketBase
+    {
+        [PacketIndex(0)]
+        public int Had { get; set; }
+
+        [PacketIndex(1, SpecialSeparator = "/")]
+        public int Total { get; set; }
+    }
+}

--- a/src/NosCore.Packets/ServerPackets/TimeSpaces/MinfoObjectiveSubPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/TimeSpaces/MinfoObjectiveSubPacket.cs
@@ -1,0 +1,22 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using NosCore.Packets.Attributes;
+
+namespace NosCore.Packets.ServerPackets.TimeSpaces
+{
+    public class MinfoObjectiveSubPacket : PacketBase
+    {
+        [PacketIndex(0)]
+        public int Vnum { get; set; }
+
+        [PacketIndex(1)]
+        public int Current { get; set; }
+
+        [PacketIndex(2, SpecialSeparator = "/")]
+        public int Total { get; set; }
+    }
+}

--- a/src/NosCore.Packets/ServerPackets/TimeSpaces/MinfoPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/TimeSpaces/MinfoPacket.cs
@@ -1,0 +1,42 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using NosCore.Packets.Attributes;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.Packets.ServerPackets.TimeSpaces
+{
+    [PacketHeader("minfo", Scope.InGame)]
+    public class MinfoPacket : PacketBase
+    {
+        [PacketIndex(0)]
+        public bool KillAllMonsters { get; set; }
+
+        [PacketIndex(1)]
+        public bool GoToExit { get; set; }
+
+        [PacketIndex(2)]
+        public MinfoObjectiveSubPacket? KillMonster { get; set; }
+
+        [PacketIndex(3)]
+        public MinfoObjectiveSubPacket? CollectItem { get; set; }
+
+        [PacketIndex(4)]
+        public MinfoConversationSubPacket? Conversation { get; set; }
+
+        [PacketIndex(5)]
+        public MinfoObjectiveSubPacket? InteractObjects { get; set; }
+
+        [PacketIndex(6)]
+        public bool ProtectNpc { get; set; }
+
+        [PacketIndex(7)]
+        public int MaxLives { get; set; }
+
+        [PacketIndex(8)]
+        public int Unknown { get; set; }
+    }
+}

--- a/src/NosCore.Packets/ServerPackets/TimeSpaces/RsfnPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/TimeSpaces/RsfnPacket.cs
@@ -1,4 +1,4 @@
-﻿//  __  _  __    __   ___ __  ___ ___
+//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -7,18 +7,18 @@
 using NosCore.Packets.Attributes;
 using NosCore.Packets.Enumerations;
 
-namespace NosCore.Packets.ServerPackets.MiniMap
+namespace NosCore.Packets.ServerPackets.TimeSpaces
 {
-    [PacketHeader("c_map", Scope.InGame)]
-    public class CMapPacket : PacketBase
+    [PacketHeader("rsfn", Scope.InGame)]
+    public class RsfnPacket : PacketBase
     {
         [PacketIndex(0)]
-        public byte Type { get; set; }
+        public int MapIndexX { get; set; }
 
         [PacketIndex(1)]
-        public short Id { get; set; }
+        public int MapIndexY { get; set; }
 
         [PacketIndex(2)]
-        public bool IsEntering { get; set; }
+        public int Status { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
Breaking field rename on `CMapPacket` plus five previously-missing packet schemas ported from vanosilla.

- **CMapPacket.MapType → IsEntering** (#276). Per vanosilla `CharacterPacketExtension.GenerateCMapPacket`, the third field is `1 = entering the map, 0 = exiting`. The old name was misleading.
- **GmsgPacket** / **GmsgSubPacket** (#233) — family daily messages, `<characterId>|<message>` list.
- **GexpPacket** / **GexpSubPacket** (#232) — family member experience, `<characterId>|<exp>` list.
- **RsfnPacket** (#222) — TimeSpace map status `rsfn <x> <y> <status>`.
- **MinfoPacket** + **MinfoObjectiveSubPacket** + **MinfoConversationSubPacket** (#221) — TimeSpace objective banner.
- **FbsPacket** (#219) — RainbowBattle scoreboard `<team> <count> <red> <blue> <small> <med> <big> <name>`.

Still-open `frank_stc` (#211) and `rbr2` (#208) are not generated by vanosilla; those need a live-capture reference before we can model them.

## Test plan
- [x] `dotnet build` — green
- [x] `dotnet test` — 113/113 (approval doc regenerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for group experience and group message server packets.
  * Added Rainbow Battle packet support.
  * Added Time Spaces mission-related packet support.

* **Improvements**
  * Renamed minimap packet property for improved clarity.

* **Documentation**
  * Updated packet documentation with new packet entries and organizational groupings.

* **Chores**
  * Version bumped to 20.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->