### PR TITLE
fix: NsTeSTPacket.LeadingBlank defaults to empty string (20.0.1)

### DIFF
--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>20.0.0</Version>
+		<Version>20.0.1</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Packets/ServerPackets/Login/NsTeSTPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Login/NsTeSTPacket.cs
@@ -16,7 +16,7 @@ namespace NosCore.Packets.ServerPackets.Login
     public class NsTestPacket : PacketBase
     {
         [PacketIndex(0)]
-        public string? LeadingBlank { get; set; }
+        public string LeadingBlank { get; set; } = string.Empty;
 
         [PacketIndex(1)]
         public RegionType RegionType { get; set; }


### PR DESCRIPTION
## Summary
Bug observed on NosCore's own login server: the wire came out as \`NsTeST - 0 admin …\` instead of the vanosilla \`NsTeST  0 admin …\` (literal double space). The serializer emits \`-\` for an unset/null string property, and \`LeadingBlank\` was \`string?\` with no default.

Make \`LeadingBlank\` non-nullable with an empty-string default so any consumer constructing an \`NsTestPacket\` automatically round-trips correctly without remembering to set it.

## Test plan
- [x] \`dotnet test\` — 113/113 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released patch version 20.0.1 as part of ongoing maintenance and stability enhancement efforts

* **Bug Fixes**
  * Improved data field handling by converting previously nullable packet data fields to non-nullable fields with appropriate default values, ensuring more robust packet processing, enhanced reliability, and prevention of potential null reference exceptions and data inconsistencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->