### PR TITLE
fix: AscrPacket leading-blank field (20.0.2)

### DIFF
--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>20.0.1</Version>
+		<Version>20.0.2</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Packets/ServerPackets/UI/AscrPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/UI/AscrPacket.cs
@@ -1,4 +1,4 @@
-﻿using NosCore.Packets.Attributes;
+using NosCore.Packets.Attributes;
 using NosCore.Packets.Enumerations;
 
 namespace NosCore.Packets.ServerPackets.UI
@@ -7,30 +7,33 @@ namespace NosCore.Packets.ServerPackets.UI
     public class AscrPacket : PacketBase
     {
         [PacketIndex(0)]
-        public int CurrentKill { get; set; }
+        public string LeadingBlank { get; set; } = string.Empty;
 
         [PacketIndex(1)]
-        public int CurrentDie { get; set; }
+        public int CurrentKill { get; set; }
 
         [PacketIndex(2)]
-        public int CurrentTc { get; set; }
+        public int CurrentDie { get; set; }
 
         [PacketIndex(3)]
-        public int ArenaKill { get; set; }
+        public int CurrentTc { get; set; }
 
         [PacketIndex(4)]
-        public int ArenaDie { get; set; }
+        public int ArenaKill { get; set; }
 
         [PacketIndex(5)]
-        public int ArenaTc { get; set; }
+        public int ArenaDie { get; set; }
 
         [PacketIndex(6)]
-        public int KillGroup { get; set; }
+        public int ArenaTc { get; set; }
 
         [PacketIndex(7)]
-        public int DieGroup { get; set; }
+        public int KillGroup { get; set; }
 
         [PacketIndex(8)]
+        public int DieGroup { get; set; }
+
+        [PacketIndex(9)]
         public AscrPacketType Type { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
Same fix pattern as NsTeST 20.0.1 and `SqstPacket`: vanosilla's `UiPacketExtension` emits `ascr  <CurrentKill> …` with a literal double space after the header. Without a `LeadingBlank` field modeled at index 0, the deserializer can't parse the empty token and the serializer emits `-` instead.

- Add `public string LeadingBlank { get; set; } = string.Empty;` at `[PacketIndex(0)]`.
- Shift every other field +1 (`CurrentKill` → 1 … `Type` → 9).

No in-tree consumer uses `AscrPacket`, so this ships as a patch (20.0.2) rather than a major bump.

## Test plan
- [x] `dotnet test` — 113/113 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 20.0.2.

* **Refactor**
  * UI packet layout changed by inserting a new leading field, shifting the order of existing fields. This is a breaking change that requires client-side updates to remain compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->