### PR TITLE
fix: IsValid accepts empty strings for non-nullable string fields (20.0.3)

### DIFF
--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>20.0.2</Version>
+		<Version>20.0.3</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Packets/PacketBase.cs
+++ b/src/NosCore.Packets/PacketBase.cs
@@ -52,7 +52,7 @@ namespace NosCore.Packets
                     var nullabilityInfo = nullabilityContext.Create(prop);
                     if (nullabilityInfo.WriteState is not NullabilityState.Nullable)
                     {
-                        var attr = new RequiredAttribute();
+                        var attr = new RequiredAttribute { AllowEmptyStrings = true };
                         var result = attr.GetValidationResult(value, vc);
                         if (result != null)
                         {


### PR DESCRIPTION
## Summary
Symptom from live NosCore login traffic:
\`\`\`
EROR -- Sending an invalid packet: header=NsTeST type=NosCore.Packets.ServerPackets.Login.NsTestPacket errors=[The NsTestPacket field is required.]
\`\`\`

[PacketBase.IsValid](src/NosCore.Packets/PacketBase.cs#L55) constructs \`new RequiredAttribute()\` which defaults to \`AllowEmptyStrings = false\`. That rejects \`NsTestPacket.LeadingBlank = ""\` — even though an empty token is exactly what the wire carries.

Switch to \`new RequiredAttribute { AllowEmptyStrings = true }\` so a non-nullable string property can legally hold \`""\`.

## Test plan
- [x] \`dotnet test\` — 113/113 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)