### PR TITLE
chore: bump all NuGet packages to latest and add Game18NConstString 2851-2868

### DIFF
--- a/src/NosCore.Packets/Enumerations/Game18NConstString.verified.cs
+++ b/src/NosCore.Packets/Enumerations/Game18NConstString.verified.cs
@@ -11737,5 +11737,65 @@ namespace NosCore.Packets.Enumerations
         // A party member's level is too low to continue.
         // <summary>
         APartyMemberSLevelIs = 2850,
+        // <summary>
+        // Destroy all the pillars by attacking them with the opposite element.
+        // <summary>
+        DestroyAllThePillarsByAttacking = 2851,
+        // <summary>
+        // Dodge the meteors! Try to avoid being hit as far as possible.
+        // <summary>
+        DodgeTheMeteorsTryToAvoid = 2852,
+        // <summary>
+        // Purify the twisted heroes!
+        // <summary>
+        PurifyTheTwistedHeroes = 2853,
+        // <summary>
+        // If you fail to purify them, everything is lost.
+        // <summary>
+        IfYouFailToPurifyThem = 2854,
+        // <summary>
+        // Defeat all mini-bosses. Only the opposite element can deal damage to them.
+        // <summary>
+        DefeatAllMiniBossesOnlyThe = 2855,
+        // <summary>
+        // Celine, Grand Master of the Petal Knights
+        // <summary>
+        CelineGrandMasterOfThePetal = 2856,
+        // <summary>
+        // Unequip the amulet first, then you can use the scroll for betting.
+        // <summary>
+        UnequipTheAmuletFirstThenYou = 2857,
+        // <summary>
+        // The shell engraving can only be applied to champion level equipment.
+        // <summary>
+        TheShellEngravingCanOnlyBe = 2861,
+        // <summary>
+        // That is someone else's exclusive item. Shell upgrades can only be performed on your own exclusive items.
+        // <summary>
+        ThatIsSomeoneElseSExclusive = 2862,
+        // <summary>
+        // The shell engraving is complete.
+        // <summary>
+        TheShellEngravingIsComplete = 2863,
+        // <summary>
+        // The effect stats could not be re-rolled.
+        // <summary>
+        TheEffectStatsCouldNotBe = 2864,
+        // <summary>
+        // Chat is accessible from rank NosBlue or level 65+.
+        // <summary>
+        ChatIsAccessibleFromRankNosBlue = 2865,
+        // <summary>
+        // This item can be used from rank NosBlue or level 65+.
+        // <summary>
+        ThisItemCanBeUsedFrom = 2866,
+        // <summary>
+        // NosMates can be summoned from rank NosBlue or level 65+.
+        // <summary>
+        NosMatesCanBeSummonedFromRank = 2867,
+        // <summary>
+        // Defeat all mini-bosses.
+        // <summary>
+        DefeatAllMiniBosses = 2868,
     }
 }

--- a/test/NosCore.Packets.Benchmark/NosCore.Packets.Benchmark.csproj
+++ b/test/NosCore.Packets.Benchmark/NosCore.Packets.Benchmark.csproj
@@ -10,7 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/test/NosCore.Packets.Tests/NosCore.Packets.Tests.csproj
+++ b/test/NosCore.Packets.Tests/NosCore.Packets.Tests.csproj
@@ -9,17 +9,17 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-		<PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-		<PackageReference Include="NosCore.ParserInputGenerator" Version="4.0.0" />
-		<PackageReference Include="Verify.MSTest" Version="31.16.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+		<PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
+		<PackageReference Include="NosCore.ParserInputGenerator" Version="4.1.0" />
+		<PackageReference Include="Verify.MSTest" Version="31.28.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Bump MSTest.TestAdapter/TestFramework 4.2.1 -> 4.3.3, Microsoft.NET.Test.Sdk 18.4.0 -> 18.8.1, coverlet.collector 10.0.0 -> 10.0.1
- Bump Microsoft.CodeAnalysis.CSharp 5.3.0 -> 5.6.0, Verify.MSTest 31.16.1 -> 31.28.0, NosCore.ParserInputGenerator 4.0.0 -> 4.1.0
- Add Game18NConstString enum entries 2851-2868 (act pillars/meteors/purify, shell engraving, NosBlue rank gating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for 17 additional in-game messages covering dimensional pillars, meteors, purification objectives, mini-bosses, shell engraving, access ranks, and item usage.
  - Expanded messaging for gameplay instructions, restrictions, completion states, and combat objectives.

- **Bug Fixes**
  - Improved coverage and consistency for newly supported game messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->