### PR TITLE
fix: a null sub-packet loses its separating space

### DIFF
--- a/src/NosCore.Packets/Serializer.cs
+++ b/src/NosCore.Packets/Serializer.cs
@@ -271,10 +271,6 @@ namespace NosCore.Packets
                 incrementExpr = Expression.Constant(!isFromList || !isOptionalSerie);
             }
 
-            // A null sub-packet is written as -1, and it has to carry the same leading separator
-            // the non-null path gets from the discriminator. Without it the -1 is glued to the
-            // field before it and the client cannot split the packet into fields at all:
-            //     sc_n ... 1536-1-1-1 -1 ...   instead of   sc_n ... 1536 -1 -1 -1 ...
             return Expression.Condition(
                 Expression.Equal(specificTypeExpression, Expression.Constant(null, typeof(object))),
                 Expression.Constant(indexAttr.IsOptional ? null : $"{discriminator}-1", typeof(object)),

--- a/src/NosCore.Packets/Serializer.cs
+++ b/src/NosCore.Packets/Serializer.cs
@@ -271,9 +271,13 @@ namespace NosCore.Packets
                 incrementExpr = Expression.Constant(!isFromList || !isOptionalSerie);
             }
 
+            // A null sub-packet is written as -1, and it has to carry the same leading separator
+            // the non-null path gets from the discriminator. Without it the -1 is glued to the
+            // field before it and the client cannot split the packet into fields at all:
+            //     sc_n ... 1536-1-1-1 -1 ...   instead of   sc_n ... 1536 -1 -1 -1 ...
             return Expression.Condition(
                 Expression.Equal(specificTypeExpression, Expression.Constant(null, typeof(object))),
-                Expression.Constant(indexAttr.IsOptional ? null : "-1", typeof(object)),
+                Expression.Constant(indexAttr.IsOptional ? null : $"{discriminator}-1", typeof(object)),
                 Expression.Convert(propExp, typeof(object))
             );
         }

--- a/test/NosCore.Packets.Tests/SerializerTest.cs
+++ b/test/NosCore.Packets.Tests/SerializerTest.cs
@@ -519,6 +519,26 @@ namespace NosCore.Packets.Tests
         }
 
         [TestMethod]
+        public void SerializeWithNullSubPacketKeepsTheSeparator()
+        {
+            var packet = Serializer.Serialize(new ScnPacket
+            {
+                PetId = 1,
+                NpcMonsterVNum = 319,
+                TransportId = 26719,
+                Level = 50,
+                Loyalty = 1000,
+                Experience = 1536,
+                WeaponInstanceDetails = new ScnPacket.ScEquipmentDetails { ItemId = 990 },
+                Name = "Kliff",
+                MorphId = -1
+            });
+
+            Assert.IsTrue(packet.StartsWith("sc_n 1 319 26719 50 1000 1536 990.0.0 -1 -1 -1 "),
+                $"the -1 of a null sub-packet must not be glued to the field before it: {packet}");
+        }
+
+        [TestMethod]
         public void SerializeWithSpecialSeparator()
         {
             var dlgTest = new BlinitPacket

--- a/test/NosCore.Packets.Tests/SerializerTest.cs
+++ b/test/NosCore.Packets.Tests/SerializerTest.cs
@@ -80,6 +80,7 @@ namespace NosCore.Packets.Tests
                 typeof(MallPacket),
                 typeof(FtptPacket),
                 typeof(ScpIndicatorPacket),
+                typeof(ScnPacket),
                 typeof(EsfPacket),
                 typeof(SopenPacket),
                 typeof(StbmPacket),


### PR DESCRIPTION
A sub-packet serialized from `null` returns `"-1"` without the leading separator that the non-null path gets from its discriminator. The `-1` ends up glued to the field before it, and the client cannot split the packet into fields at all.

```
sc_n 1 319 26719 50 1000 1536-1-1-1 -1 0 ...      <- today
sc_n 1 319 26719 50 1000 1536 -1 -1 -1 0 ...      <- expected
```

It shows up anywhere a sub-packet property can be null. Today that is `sc_n`'s four equipment slots and `gidx`'s family identifier — I hit it building both (NosCoreIO/NosCore#2281, NosCoreIO/NosCore#2283).

One-line fix in `Serializer.PacketSerializer`, plus a regression test on `sc_n`.

Two test failures on master are pre-existing and unrelated — `DocumentationTest` refuses CRLF checkouts on Windows; they fail identically with this change reverted.

---

While I was here: `StringSerializer` already replaces the separator with `^` for every non-final string field, so callers do **not** need to do it by hand. I had been doing exactly that in NosCore and you were right to flag it — I am removing it there, no change needed here.

One thing I would like your opinion on rather than change unilaterally: `GidxPacket.FamilyIdentifier` is modelled as a `serverId.familyId` compound sub-packet, but a packet capture writes that field as a single family id in all 670 `gidx` lines — not one contains a dot — and `-1` when the character has no family. As modelled it can produce neither. Would you like a follow-up flattening it to a nullable id, or is the compound deliberate for something cross-server?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that missing required sub-packets preserve the expected separator and `-1` placeholder during serialization.
  * Verified that optional missing sub-packets continue to serialize as `null`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->