### PR TITLE
chore: bump NosCore.Packets to 21.0.0

### DIFF
--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>20.0.3</Version>
+		<Version>21.0.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Release bump so #494 can reach nuget.org. Nothing has shipped since `20.0.3`, so #493 and #494 go out together — meaning the reverted serializer patch never reaches a consumer at all.

Major rather than patch because the public surface changed:
- `GidxFamilySubPacket` deleted
- `GidxPacket.FamilyIdentifier` (sub-packet) → `GidxPacket.FamilyId` (`long?`)

Nothing in NosCore referenced either, so the practical impact is nil, but removing a public type is a major by semver.

115/115 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)