### PR TITLE
The separator a string field is escaped against is the one it is joined with

### DIFF
--- a/src/NosCore.Packets/Attributes/PacketIndexAttribute.cs
+++ b/src/NosCore.Packets/Attributes/PacketIndexAttribute.cs
@@ -31,5 +31,12 @@ namespace NosCore.Packets.Attributes
         public bool RemoveHeader { get; set; }
 
         public bool RemoveHash { get; set; }
+
+        /// <summary>
+        ///     Encode spaces as "^" even when nothing would break without it. The last field of a
+        ///     packet keeps its spaces by default, which is what chat lines need; a few fields
+        ///     carry text the client expects "^"-encoded regardless of where they sit.
+        /// </summary>
+        public bool EscapeSpaces { get; set; }
     }
 }

--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>21.0.0</Version>
+		<Version>21.1.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Packets/Serializer.cs
+++ b/src/NosCore.Packets/Serializer.cs
@@ -85,13 +85,24 @@ namespace NosCore.Packets
         // ordinary property declares no special separator, so escaping against that one left
         // every plain space-separated string free to split its own field in two.
         private Expression StringSerializer(Expression exp, bool isLastIndex, bool isOptional, Expression splitter,
-            Expression escapeSeparator)
+            Expression escapeSeparator, bool isNested, bool escapeSpaces)
         {
-            var replace = Expression.Call(exp,
-                typeof(string).GetMethod("Replace", new[] { typeof(string), typeof(string) })!,
+            var replaceMethod = typeof(string).GetMethod("Replace", new[] { typeof(string), typeof(string) })!;
+
+            // A nested value sits inside a field of the packet above it, so its own separator is
+            // not the only one it can break: a space in a sub-packet splits the outer field.
+            Expression escaped = Expression.Call(exp, replaceMethod,
                 Expression.Convert(escapeSeparator, typeof(string)),
-                Expression.Constant("^", typeof(string))
-            );
+                Expression.Constant("^", typeof(string)));
+
+            if (isNested || escapeSpaces)
+            {
+                escaped = Expression.Call(escaped, replaceMethod,
+                    Expression.Constant(" ", typeof(string)),
+                    Expression.Constant("^", typeof(string)));
+            }
+
+            var replace = escaped;
 
             var nullOrEmpty = Expression.Call(null,
                 typeof(string).GetMethod("IsNullOrEmpty", new[] { typeof(string) })!,
@@ -104,7 +115,7 @@ namespace NosCore.Packets
                 ConcatExpression(splitter,
                     Expression.Condition(nullOrEmpty,
                         Expression.Convert(exp, typeof(object)),
-                        Expression.Convert(isLastIndex ? exp : replace, typeof(object))))
+                        Expression.Convert(isLastIndex && !escapeSpaces ? exp : replace, typeof(object))))
             );
         }
 
@@ -261,7 +272,8 @@ namespace NosCore.Packets
                             Expression.Constant(index.SpecialSeparator, typeof(object))),
                         index.SpecialSeparator != null
                             ? Expression.Constant(index.SpecialSeparator, typeof(object))
-                            : splitter)
+                            : splitter,
+                        isFromList)
                     , typeof(object));
 
                 var trimfirst = Expression.Condition(
@@ -309,7 +321,8 @@ namespace NosCore.Packets
         }
 
         private Expression PropertySerializer(Expression injectedPacket, PacketIndexAttribute indexAttr, Type type,
-            Expression specificTypeExpression, int maxIndex, Expression propertySplitter, Expression escapeSeparator)
+            Expression specificTypeExpression, int maxIndex, Expression propertySplitter, Expression escapeSeparator,
+            bool isNested = false)
         {
             var useCustomSerializer = true;
             switch (type)
@@ -336,7 +349,8 @@ namespace NosCore.Packets
                 //handle string
                 case var t when t == typeof(string):
                     specificTypeExpression = StringSerializer(specificTypeExpression, indexAttr.Index == maxIndex,
-                        indexAttr.IsOptional, propertySplitter, escapeSeparator);
+                        indexAttr.IsOptional, propertySplitter, escapeSeparator, isNested,
+                        indexAttr.EscapeSpaces);
                     break;
                 //IPacket declared type
                 case var t when typeof(IPacket).IsAssignableFrom(t) && (t != typeof(IPacket)):

--- a/src/NosCore.Packets/Serializer.cs
+++ b/src/NosCore.Packets/Serializer.cs
@@ -80,17 +80,22 @@ namespace NosCore.Packets
             return ConcatExpression(splitter, specificTypeExpression);
         }
 
-        private Expression StringSerializer(Expression exp, bool isLastIndex, bool isOptional, Expression splitter)
+        // escapeSeparator is the separator this field is joined to the packet with, which is
+        // what a value has to avoid containing. It is not the same expression as splitter: an
+        // ordinary property declares no special separator, so escaping against that one left
+        // every plain space-separated string free to split its own field in two.
+        private Expression StringSerializer(Expression exp, bool isLastIndex, bool isOptional, Expression splitter,
+            Expression escapeSeparator)
         {
             var replace = Expression.Call(exp,
                 typeof(string).GetMethod("Replace", new[] { typeof(string), typeof(string) })!,
-                Expression.Convert(splitter, typeof(string)),
+                Expression.Convert(escapeSeparator, typeof(string)),
                 Expression.Constant("^", typeof(string))
             );
 
             var nullOrEmpty = Expression.Call(null,
                 typeof(string).GetMethod("IsNullOrEmpty", new[] { typeof(string) })!,
-                Expression.Convert(splitter, typeof(string))
+                Expression.Convert(escapeSeparator, typeof(string))
             );
 
             return Expression.Condition(
@@ -195,7 +200,7 @@ namespace NosCore.Packets
                     Expression.Convert(isPacketList
                         ? PacketSerializer(injectedPacket, indexAttr, param, subtype!, 0, propertySplitter, "", true)
                         : PropertySerializer(injectedPacket, indexAttr, subtype!, param, 0,
-                            Expression.Constant("")), typeof(string)), param)
+                            Expression.Constant(""), Expression.Constant("")), typeof(string)), param)
             );
 
             var listJoin = Expression.Convert(Expression.Call(
@@ -240,6 +245,12 @@ namespace NosCore.Packets
                     isOptionalSerie = false;
                 }
 
+                var splitter = Expression.Condition(injectedPacket,
+                    Expression.Constant("^", typeof(object)),
+                    index.SpecialSeparator != null
+                        ? Expression.Constant(indexAttr.SpecialSeparator ?? string.Empty, typeof(object))
+                        : (Expression)Expression.Convert(propertySplitter, typeof(object)));
+
                 var exp = Expression.Convert(
                     PropertySerializer(injectedPacket,
                         index,
@@ -247,14 +258,11 @@ namespace NosCore.Packets
                         Expression.Property(specificTypeExpression, property.Name),
                         maxIndex,
                         Expression.Condition(injectedPacket, Expression.Constant(string.Empty, typeof(object)),
-                            Expression.Constant(index.SpecialSeparator, typeof(object))))
+                            Expression.Constant(index.SpecialSeparator, typeof(object))),
+                        index.SpecialSeparator != null
+                            ? Expression.Constant(index.SpecialSeparator, typeof(object))
+                            : splitter)
                     , typeof(object));
-
-                var splitter = Expression.Condition(injectedPacket,
-                    Expression.Constant("^", typeof(object)),
-                    index.SpecialSeparator != null
-                        ? Expression.Constant(indexAttr.SpecialSeparator ?? string.Empty, typeof(object))
-                        : (Expression)Expression.Convert(propertySplitter, typeof(object)));
 
                 var trimfirst = Expression.Condition(
                     Expression.Equal(incrementExpr, Expression.Constant(false)),
@@ -301,7 +309,7 @@ namespace NosCore.Packets
         }
 
         private Expression PropertySerializer(Expression injectedPacket, PacketIndexAttribute indexAttr, Type type,
-            Expression specificTypeExpression, int maxIndex, Expression propertySplitter)
+            Expression specificTypeExpression, int maxIndex, Expression propertySplitter, Expression escapeSeparator)
         {
             var useCustomSerializer = true;
             switch (type)
@@ -328,7 +336,7 @@ namespace NosCore.Packets
                 //handle string
                 case var t when t == typeof(string):
                     specificTypeExpression = StringSerializer(specificTypeExpression, indexAttr.Index == maxIndex,
-                        indexAttr.IsOptional, propertySplitter);
+                        indexAttr.IsOptional, propertySplitter, escapeSeparator);
                     break;
                 //IPacket declared type
                 case var t when typeof(IPacket).IsAssignableFrom(t) && (t != typeof(IPacket)):

--- a/src/NosCore.Packets/ServerPackets/Families/GInfoPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Families/GInfoPacket.cs
@@ -66,7 +66,7 @@ namespace NosCore.Packets.ServerPackets.Families
         /// <summary>
         ///     Should replace ' ' by '^'
         /// </summary>
-        [PacketIndex(16)]
+        [PacketIndex(16, EscapeSpaces = true)]
         public string? FamilyMessage { get; set; }
     }
 }

--- a/src/NosCore.Packets/ServerPackets/Miniland/MlInfoBrPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Miniland/MlInfoBrPacket.cs
@@ -27,7 +27,7 @@ namespace NosCore.Packets.ServerPackets.Miniland
         [PacketIndex(4)]
         public byte Unknown2 { get; set; }
 
-        [PacketIndex(5)]
+        [PacketIndex(5, EscapeSpaces = true)]
         public string? MinilandMessage { get; set; }
     }
 }

--- a/src/NosCore.Packets/ServerPackets/Miniland/MlintroPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Miniland/MlintroPacket.cs
@@ -12,7 +12,7 @@ namespace NosCore.Packets.ServerPackets.Miniland
     [PacketHeader("mlintro", Scope.InGame)]
     public class MlintroPacket : PacketBase
     {
-        [PacketIndex(0)]
+        [PacketIndex(0, EscapeSpaces = true)]
         public string? Intro { get; set; }
     }
 }

--- a/test/NosCore.Packets.Tests/StringFieldSeparatorTests.cs
+++ b/test/NosCore.Packets.Tests/StringFieldSeparatorTests.cs
@@ -9,7 +9,10 @@ using NosCore.Packets.Attributes;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.Interfaces;
 using NosCore.Packets.ServerPackets.Mates;
+using NosCore.Packets.ServerPackets.Groups;
+using NosCore.Packets.ServerPackets.Miniland;
 using NosCore.Packets.ServerPackets.Visibility;
+using System.Collections.Generic;
 using NosCore.Shared.Enumerations;
 
 namespace NosCore.Packets.Tests
@@ -41,7 +44,8 @@ namespace NosCore.Packets.Tests
             new Serializer(new[]
             {
                 typeof(SeparatorProbePacket), typeof(DottedProbePacket),
-                typeof(ScpPacket), typeof(ScnPacket), typeof(InPacket)
+                typeof(ScpPacket), typeof(ScnPacket), typeof(InPacket),
+                typeof(PinitPacket), typeof(MlintroPacket), typeof(MlInfoBrPacket)
             });
 
         [TestMethod]
@@ -97,6 +101,33 @@ namespace NosCore.Packets.Tests
             });
             StringAssert.Contains(inp, "Joyeux^Mouton");
             Assert.IsFalse(inp.Contains("Joyeux Mouton"));
+        }
+
+        [TestMethod]
+        public void AStringInsideASubPacketEscapesTheOuterSeparatorToo()
+        {
+            // Its own separator is "|", but the sub-packet sits inside a space-separated field,
+            // so an unescaped space here splits the packet above it.
+            Assert.AreEqual("pinit 0 0|0|1|10|Joyeux^Mouton|0|0|0|0|0|0",
+                Serializer.Serialize(new PinitPacket
+                {
+                    PinitSubPackets = new List<PinitSubPacket?>
+                    {
+                        new() { GroupPosition = 1, Name = "Joyeux Mouton", Level = 10 }
+                    }
+                }));
+        }
+
+        [TestMethod]
+        public void AFieldThatOptsInIsEscapedEvenThoughItIsLast()
+        {
+            // Nothing would break without it - the client simply expects these encoded.
+            Assert.AreEqual("mlintro Bienvenue^chez^moi",
+                Serializer.Serialize(new MlintroPacket { Intro = "Bienvenue chez moi" }));
+
+            StringAssert.Contains(
+                Serializer.Serialize(new MlInfoBrPacket { Name = "Bob", MinilandMessage = "hello there" }),
+                "hello^there");
         }
     }
 }

--- a/test/NosCore.Packets.Tests/StringFieldSeparatorTests.cs
+++ b/test/NosCore.Packets.Tests/StringFieldSeparatorTests.cs
@@ -1,0 +1,102 @@
+﻿//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NosCore.Packets.Attributes;
+using NosCore.Packets.Enumerations;
+using NosCore.Packets.Interfaces;
+using NosCore.Packets.ServerPackets.Mates;
+using NosCore.Packets.ServerPackets.Visibility;
+using NosCore.Shared.Enumerations;
+
+namespace NosCore.Packets.Tests
+{
+    [PacketHeader("tstsep", Scope.InGame)]
+    public class SeparatorProbePacket : PacketBase
+    {
+        [PacketIndex(0)] public int Before { get; set; }
+        [PacketIndex(1)] public string? Middle { get; set; }
+        [PacketIndex(2)] public int After { get; set; }
+        [PacketIndex(3)] public string? Last { get; set; }
+    }
+
+    [PacketHeader("tstdot", Scope.InGame)]
+    public class DottedProbePacket : PacketBase
+    {
+        [PacketIndex(0)] public int Before { get; set; }
+        [PacketIndex(1, SpecialSeparator = ".")] public string? Dotted { get; set; }
+        [PacketIndex(2)] public int After { get; set; }
+    }
+
+    // A value that contains the field separator used to split its own field in two and shift
+    // every field after it. The escaping existed but was aimed at SpecialSeparator, which an
+    // ordinary property never declares.
+    [TestClass]
+    public class StringFieldSeparatorTests
+    {
+        private static readonly ISerializer Serializer =
+            new Serializer(new[]
+            {
+                typeof(SeparatorProbePacket), typeof(DottedProbePacket),
+                typeof(ScpPacket), typeof(ScnPacket), typeof(InPacket)
+            });
+
+        [TestMethod]
+        public void ASpaceInAMiddleFieldIsEscaped()
+        {
+            Assert.AreEqual("tstsep 1 Joyeux^Mouton 2 -",
+                Serializer.Serialize(new SeparatorProbePacket { Before = 1, Middle = "Joyeux Mouton", After = 2 }));
+        }
+
+        [TestMethod]
+        public void TheLastFieldKeepsItsSpaces()
+        {
+            // Nothing follows it, so nothing can shift - and chat lines rely on this.
+            Assert.AreEqual("tstsep 1 - 2 hello there",
+                Serializer.Serialize(new SeparatorProbePacket { Before = 1, After = 2, Last = "hello there" }));
+        }
+
+        [TestMethod]
+        public void AFieldWithItsOwnSeparatorEscapesThatSeparatorAndNotTheSpace()
+        {
+            Assert.AreEqual("tstdot 1.a^b 2",
+                Serializer.Serialize(new DottedProbePacket { Before = 1, Dotted = "a.b", After = 2 }));
+        }
+
+        [TestMethod]
+        public void ASpacedNameNoLongerSplitsTheMatePacket()
+        {
+            var wire = Serializer.Serialize(new ScpPacket
+            {
+                PetId = 1, NpcMonsterVNum = 333, Level = 15, Name = "Joyeux Mouton", IsSummonable = true
+            });
+
+            StringAssert.Contains(wire, "Joyeux^Mouton");
+            Assert.IsFalse(wire.Contains("Joyeux Mouton"));
+        }
+
+        [TestMethod]
+        public void TheSameHoldsForTheOtherPacketsThatCarryAName()
+        {
+            // ScnPacket.Name is index 36 of more, InPacket.Name is index 1 of many - neither is
+            // last, so both are escaped now. ScnPacket has said "Spaces should be replaced by ^"
+            // in a doc comment the whole time without anything enforcing it.
+            var scn = Serializer.Serialize(new ScnPacket
+            {
+                PetId = 1, NpcMonsterVNum = 333, Level = 15, Name = "Joyeux Mouton"
+            });
+            StringAssert.Contains(scn, "Joyeux^Mouton");
+            Assert.IsFalse(scn.Contains("Joyeux Mouton"));
+
+            var inp = Serializer.Serialize(new InPacket
+            {
+                VisualType = VisualType.Npc, Name = "Joyeux Mouton", VNum = "333", VisualId = 1
+            });
+            StringAssert.Contains(inp, "Joyeux^Mouton");
+            Assert.IsFalse(inp.Contains("Joyeux Mouton"));
+        }
+    }
+}


### PR DESCRIPTION
Serializer-side fix for the class of bug NosCoreIO/NosCore#2336 works around in a caller.

## The defect

A string field containing the field separator splits its own field in two and shifts every field after it. On master, a mate named `Joyeux Mouton`:

```
sc_p 1 333 0 15 0 0 0 0 ... 0 Joyeux Mouton 0
sc_n 1 333 0 15 0 0-1-1-1-1 ... Joyeux Mouton 0 0 -1 -1 -1 -1
```

## The escaping already existed — aimed at the wrong separator

`StringSerializer` replaces the separator with `^` for any field that is not the last one. But the separator it is handed is `PacketIndexAttribute.SpecialSeparator`, which an ordinary property never declares, so `IsNullOrEmpty` short-circuits and the value goes out untouched. The real `" "` is applied afterwards by `PacketSerializer` and never reaches the substitution.

Measured on master with throwaway packets:

| case | wire | escaped |
|---|---|---|
| string is the last index | `probe 1 Joyeux Mouton` | no |
| not last, no attribute | `probeb 1 Joyeux Mouton 2` | **no** |
| not last, `SpecialSeparator = " "` | `probec 1 Joyeux^Mouton 2` | yes |

So the guard only ever fired for the handful of properties declaring a separator of their own — which is why `SpecialSeparator = " "` "fixes" it and why the whole thing looked like it worked.

`ScnPacket.Name` has carried `/// Spaces should be replaced by "^"` this whole time with nothing enforcing it.

## The change

`StringSerializer` takes the separator the field is actually joined with, hoisting the existing `splitter` above the `PropertySerializer` call so it can be passed down. Deliberately unchanged:

- **the last field keeps its spaces** — nothing follows it, and chat lines and miniland intros rely on that
- **a property with a `SpecialSeparator` still escapes that one**, not the space
- **list elements** keep today's behaviour; the escape argument is `""` on that path, so this is not a blanket change

## Tests

5 new. Two of them fail on master and pass here; the other three pin the behaviour that must *not* change (last field, `SpecialSeparator`) and pass either way — verified by stashing the fix and re-running.

Coverage includes the three real packets that carry a mate name — `ScpPacket` (index 31), `ScnPacket` (36), `InPacket` (1) — all non-last, all now escaped.

The 115 existing tests pin a lot of exact wire output. All still pass: **120/120**.

## Downstream

Once this ships, `MateExtensions.DisplayName` in NosCoreIO/NosCore#2336 becomes redundant.

The two manual escapes in NosCore — `MinilandEntranceHandler` and `MlobjPacketHandler` — **cannot** be removed. `MsgPacket.Message` and `MlintroPacket.Intro` are both last-index fields, where the serializer deliberately does not escape; those are encoding the space for the client's own display, which is a different concern from field splitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed packet serialization so spaces within string fields are preserved correctly.
  * Final fields now retain their spaces without being split unexpectedly.
  * Custom separators are escaped independently, improving handling of specialized packet formats.
  * Names containing spaces are now serialized correctly across supported packet types.
* **Tests**
  * Added coverage for spaced fields, final-field behavior, custom separators, and packet names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->