### PR TITLE
The personal warehouse headers are pstash and pstash_all

### DIFF
--- a/documentation/DocumentationTest.PacketsDocumentation.verified.md
+++ b/documentation/DocumentationTest.PacketsDocumentation.verified.md
@@ -522,7 +522,7 @@
 ### Warehouse
 - [f_stash_all](../src/NosCore.Packets/ServerPackets/Warehouse/FStashAllPacket.cs) *InGame*
 - [f_stash](../src/NosCore.Packets/ServerPackets/Warehouse/FStashClientPacket.cs) *InGame*
-- [p_stash_all](../src/NosCore.Packets/ServerPackets/Warehouse/PStashAllPacket.cs) *InGame*
-- [p_stash](../src/NosCore.Packets/ServerPackets/Warehouse/PStashClientPacket.cs) *InGame*
+- [pstash_all](../src/NosCore.Packets/ServerPackets/Warehouse/PStashAllPacket.cs) *InGame*
+- [pstash](../src/NosCore.Packets/ServerPackets/Warehouse/PStashClientPacket.cs) *InGame*
 - [stash_all](../src/NosCore.Packets/ServerPackets/Warehouse/StashAllPacket.cs) *InGame*
 - [stash](../src/NosCore.Packets/ServerPackets/Warehouse/StashClientPacket.cs) *InGame*

--- a/src/NosCore.Packets/ServerPackets/Warehouse/PStashAllPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Warehouse/PStashAllPacket.cs
@@ -11,7 +11,7 @@ using NosCore.Packets.ServerPackets.Inventory;
 
 namespace NosCore.Packets.ServerPackets.Warehouse
 {
-    [PacketHeader("p_stash_all", Scope.InGame)]
+    [PacketHeader("pstash_all", Scope.InGame)]
     public class PStashAllPacket : PacketBase
     {
         [PacketIndex(0)]

--- a/src/NosCore.Packets/ServerPackets/Warehouse/PStashClientPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Warehouse/PStashClientPacket.cs
@@ -11,7 +11,7 @@ using NosCore.Packets.ServerPackets.Inventory;
 
 namespace NosCore.Packets.ServerPackets.Warehouse
 {
-    [PacketHeader("p_stash", Scope.InGame)]
+    [PacketHeader("pstash", Scope.InGame)]
     public class PStashClientPacket : PacketBase
     {
         [PacketListIndex(0)]


### PR DESCRIPTION
## What

`PStashClientPacket` and `PStashAllPacket` declare the headers `p_stash` and `p_stash_all`. The
client's packet name table lists `pstash` and `pstash_all`, without the underscore, and `p_stash`
/ `p_stash_all` do not appear in it at all — searched both as length-prefixed strings and as raw
substrings, zero occurrences. Anything sent under those two headers is dropped, so the personal
warehouse never draws.

What makes the mistake easy is that the client is not consistent with itself. The *family*
warehouse really is `f_stash` / `f_stash_all` **with** the underscore, and those two are right as
they stand; only the personal pair drops it. The two pairs sit about a kilobyte apart in the same
table, together with `stash` / `stash_all`.

Header strings only — no field changed.

## What was tested

* `dotnet build NosCore.Packets.sln`: 0 warnings. `dotnet test NosCore.Packets.sln`: 122/122
  green, with the documentation snapshot updated in the same commit.
* The client executable, searched for all six warehouse headers: `pstash_all`, `pstash`,
  `f_stash_all`, `f_stash`, `stash_all`, `stash` all present in the header table; `p_stash` and
  `p_stash_all` absent.
* **Not played.** No client was run against a server carrying this branch, so the warehouse
  window itself was not observed opening — the evidence here is the header table and the tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated warehouse packet identifiers to use the correct `pstash_all` and `pstash` names.
  - Improved compatibility for warehouse stash-all and stash operations.

- **Documentation**
  - Updated ServerPackets documentation to reflect the corrected identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->