### PR TITLE
Cut the caret comments back to the one a reader would get wrong

### DIFF
--- a/src/NosCore.Packets/Attributes/PacketIndexAttribute.cs
+++ b/src/NosCore.Packets/Attributes/PacketIndexAttribute.cs
@@ -32,11 +32,6 @@ namespace NosCore.Packets.Attributes
 
         public bool RemoveHash { get; set; }
 
-        /// <summary>
-        ///     Encode spaces as "^" even when nothing would break without it. The last field of a
-        ///     packet keeps its spaces by default, which is what chat lines need; a few fields
-        ///     carry text the client expects "^"-encoded regardless of where they sit.
-        /// </summary>
         public bool EscapeSpaces { get; set; }
     }
 }

--- a/src/NosCore.Packets/Serializer.cs
+++ b/src/NosCore.Packets/Serializer.cs
@@ -80,21 +80,16 @@ namespace NosCore.Packets
             return ConcatExpression(splitter, specificTypeExpression);
         }
 
-        // escapeSeparator is the separator this field is joined to the packet with, which is
-        // what a value has to avoid containing. It is not the same expression as splitter: an
-        // ordinary property declares no special separator, so escaping against that one left
-        // every plain space-separated string free to split its own field in two.
         private Expression StringSerializer(Expression exp, bool isLastIndex, bool isOptional, Expression splitter,
             Expression escapeSeparator, bool isNested, bool escapeSpaces)
         {
             var replaceMethod = typeof(string).GetMethod("Replace", new[] { typeof(string), typeof(string) })!;
 
-            // A nested value sits inside a field of the packet above it, so its own separator is
-            // not the only one it can break: a space in a sub-packet splits the outer field.
             Expression escaped = Expression.Call(exp, replaceMethod,
                 Expression.Convert(escapeSeparator, typeof(string)),
                 Expression.Constant("^", typeof(string)));
 
+            // A nested value also sits inside a field of the packet above it.
             if (isNested || escapeSpaces)
             {
                 escaped = Expression.Call(escaped, replaceMethod,

--- a/test/NosCore.Packets.Tests/StringFieldSeparatorTests.cs
+++ b/test/NosCore.Packets.Tests/StringFieldSeparatorTests.cs
@@ -34,9 +34,6 @@ namespace NosCore.Packets.Tests
         [PacketIndex(2)] public int After { get; set; }
     }
 
-    // A value that contains the field separator used to split its own field in two and shift
-    // every field after it. The escaping existed but was aimed at SpecialSeparator, which an
-    // ordinary property never declares.
     [TestClass]
     public class StringFieldSeparatorTests
     {
@@ -58,7 +55,6 @@ namespace NosCore.Packets.Tests
         [TestMethod]
         public void TheLastFieldKeepsItsSpaces()
         {
-            // Nothing follows it, so nothing can shift - and chat lines rely on this.
             Assert.AreEqual("tstsep 1 - 2 hello there",
                 Serializer.Serialize(new SeparatorProbePacket { Before = 1, After = 2, Last = "hello there" }));
         }
@@ -85,9 +81,6 @@ namespace NosCore.Packets.Tests
         [TestMethod]
         public void TheSameHoldsForTheOtherPacketsThatCarryAName()
         {
-            // ScnPacket.Name is index 36 of more, InPacket.Name is index 1 of many - neither is
-            // last, so both are escaped now. ScnPacket has said "Spaces should be replaced by ^"
-            // in a doc comment the whole time without anything enforcing it.
             var scn = Serializer.Serialize(new ScnPacket
             {
                 PetId = 1, NpcMonsterVNum = 333, Level = 15, Name = "Joyeux Mouton"
@@ -106,8 +99,6 @@ namespace NosCore.Packets.Tests
         [TestMethod]
         public void AStringInsideASubPacketEscapesTheOuterSeparatorToo()
         {
-            // Its own separator is "|", but the sub-packet sits inside a space-separated field,
-            // so an unescaped space here splits the packet above it.
             Assert.AreEqual("pinit 0 0|0|1|10|Joyeux^Mouton|0|0|0|0|0|0",
                 Serializer.Serialize(new PinitPacket
                 {
@@ -121,7 +112,6 @@ namespace NosCore.Packets.Tests
         [TestMethod]
         public void AFieldThatOptsInIsEscapedEvenThoughItIsLast()
         {
-            // Nothing would break without it - the client simply expects these encoded.
             Assert.AreEqual("mlintro Bienvenue^chez^moi",
                 Serializer.Serialize(new MlintroPacket { Intro = "Bienvenue chez moi" }));
 


### PR DESCRIPTION
Follow-up to #499, which landed with far more comment than it earned.

Twelve blocks become one line. What goes:

- the four-line note on `StringSerializer`'s `escapeSeparator` parameter — the parameter name says what it is, and why the old one was wrong belongs in #499's commit message, where it already is
- the XML doc on `EscapeSpaces` — it was the only one in `PacketIndexAttribute`; `IsOptional`, `SpecialSeparator`, `RemoveHeader` and `RemoveHash` all carry none
- five comments in the test file, each restating its own test name

What stays, one line: escaping a space when the separator is `"|"` reads as a mistake until you know the sub-packet sits inside a field of the packet above it.

122 tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified internal code comments describing string escaping and nested packet values.
  * Removed outdated property and test annotations without changing functionality or test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->