### PR TITLE
A sub-packet's last field is its own, not the parent's

### DIFF
--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>21.1.0</Version>
+		<Version>21.1.1</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Packets/Serializer.cs
+++ b/src/NosCore.Packets/Serializer.cs
@@ -368,7 +368,13 @@ namespace NosCore.Packets
                         header = " ";
                     }
 
-                    specificTypeExpression = PacketSerializer(injectedPacket, indexAttr, specificTypeExpression, t, maxIndex,
+                    // A sub-packet's fields are numbered from its own zero, so the parent's
+                    // maxIndex would mark whichever field happens to share that number as last.
+                    var subMaxIndex = t.GetProperties()
+                        .SelectMany(x => x.GetCustomAttributes(true).OfType<PacketIndexAttribute>())
+                        .Select(x => x.Index).DefaultIfEmpty(0).Max();
+
+                    specificTypeExpression = PacketSerializer(injectedPacket, indexAttr, specificTypeExpression, t, subMaxIndex,
                         propertySplitter, indexAttr.RemoveHeader ? "" : header ?? "");
                     break;
                 case var t when t == typeof(IPacket):

--- a/test/NosCore.Packets.Tests/StringFieldSeparatorTests.cs
+++ b/test/NosCore.Packets.Tests/StringFieldSeparatorTests.cs
@@ -129,5 +129,21 @@ namespace NosCore.Packets.Tests
                 Serializer.Serialize(new MlInfoBrPacket { Name = "Bob", MinilandMessage = "hello there" }),
                 "hello^there");
         }
+
+        [TestMethod]
+        public void ASubPacketFieldIsNotTreatedAsLastBecauseTheParentEndsThere()
+        {
+            // InNonPlayerSubPacket.Name is index 9, and so is the sub-packet on InPacket, so
+            // the name used to inherit the parent's last-field exemption and keep its spaces.
+            var wire = Serializer.Serialize(new InPacket
+            {
+                VisualType = VisualType.Npc,
+                VNum = "333",
+                VisualId = 2000001,
+                InNonPlayerSubPacket = new InNonPlayerSubPacket { Name = "Joyeux Mouton" }
+            });
+
+            StringAssert.Contains(wire, "Joyeux^Mouton");
+        }
     }
 }


### PR DESCRIPTION
Follow-up to #499, found while removing the manual escape from NosCoreIO/NosCore#2336.

## The defect

`PacketSerializer` passed the parent's `maxIndex` down when recursing into a sub-packet, so `indexAttr.Index == maxIndex` was comparing a nested field's number against the outer packet's. Whichever nested field happened to share that number inherited the last-field exemption and kept its spaces.

`InPacket` ends at index 9. `InNonPlayerSubPacket.Name` is index 9. So a spaced mate name went out as

```
in 2 333 2000001 0 0 0 0 0 0 0 3 42 1 0 -1 Joyeux Mouton 0 -1 0 0 ...
```

which is the same field-splitting #499 set out to fix — it just reached the name by a different route, and #499 did not cover it.

## The change

Each sub-packet gets its own `maxIndex`, so the exemption applies where a field really does end the line and nowhere else. `sc_p` and `sc_n` were already correct because their names are plain properties, not nested ones.

## Tests

One new, pinning `in` with a spaced sub-packet name. It fails with the fix stashed and passes with it. 123 total, and the 115 that pin exact wire output are unchanged.

Released as 21.1.1.