### PR TITLE
ci: read GITHUB_REF from the environment, version the package from the tag

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Check Tag
       id: check-tag
       run: |
-        if [[ ${{ github.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        if [[ "$GITHUB_REF" =~ ^refs/tags/[0-9]+.[0-9]+.[0-9]+$ ]]; then
             echo "match=true" >> $GITHUB_OUTPUT
         fi
         
@@ -39,7 +39,7 @@ jobs:
         TAG_NAME=${GITHUB_REF#refs/tags/}
         dotnet restore
         dotnet build -c Release
-        dotnet pack -c Release -o /tmp/nupkgs -v m -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+        dotnet pack -c Release -o /tmp/nupkgs -v m -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:PackageVersion=${TAG_NAME}
         dotnet nuget push /tmp/nupkgs/NosCore.Packets.${TAG_NAME}.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}
         echo "ARTIFACT_PATH=/tmp/nupkgs/NosCore.Packets.${TAG_NAME}.nupkg" >> $GITHUB_OUTPUT
         echo "ARTIFACT_NAME=NosCore.Packets.${TAG_NAME}.nupkg" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Same hardening as applied across the other package repos (flagged by review on NosCoreIO/NosCore.Shared#260):

- `${{ github.ref }}` interpolated into the Bash `[[ ... =~ ]]` check is evaluated by the shell **before** the regex filters it — a tag like `1.2.3$(...)` would execute on a runner that holds the NuGet API key. Reading `$GITHUB_REF` from the environment removes the injection point.
- `dotnet pack -p:PackageVersion=${TAG_NAME}` — the pushed filename is derived from the tag, so the package version must match it; previously a tag that didn't match the csproj version made `dotnet nuget push` fail on a missing file (the usual "bump csproj before tagging" dance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release package version detection from Git tags.
  * Ensured packaged .NET artifacts use the correct tag-based version.
  * Updated version format validation for more reliable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->