### PR TITLE
ci: read-only build job, write token confined to the tag release job

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,32 +7,51 @@ on:
       - '*.*.*'
   pull_request:
     branches: [ master ]
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '10.0.x'
-        
-    - name: Check Tag
-      id: check-tag
-      run: |
-        if [[ "$GITHUB_REF" =~ ^refs/tags/[0-9]+.[0-9]+.[0-9]+$ ]]; then
-            echo "match=true" >> $GITHUB_OUTPUT
-        fi
-        
+
     - name: Run Unit Tests
       run: |
         dotnet restore
         dotnet build
         dotnet test test/NosCore.Packets.Tests -v m
-        
-    - name: Build Artifact
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '10.0.x'
+
+    - name: Check Tag
+      id: check-tag
+      run: |
+        if [[ "$GITHUB_REF" =~ ^refs/tags/[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            echo "match=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Pack and push to NuGet
       if: steps.check-tag.outputs.match == 'true'
       id: build_artifact
       run: |
@@ -42,11 +61,10 @@ jobs:
         dotnet pack -c Release -o /tmp/nupkgs -v m -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:PackageVersion=${TAG_NAME}
         dotnet nuget push /tmp/nupkgs/NosCore.Packets.${TAG_NAME}.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}
         echo "ARTIFACT_PATH=/tmp/nupkgs/NosCore.Packets.${TAG_NAME}.nupkg" >> $GITHUB_OUTPUT
-        echo "ARTIFACT_NAME=NosCore.Packets.${TAG_NAME}.nupkg" >> $GITHUB_OUTPUT
-        
+
     - name: Upload Release Asset
       if: steps.check-tag.outputs.match == 'true'
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         files: ${{ steps.build_artifact.outputs.ARTIFACT_PATH }}
       env:


### PR DESCRIPTION
Same hardening review feedback applied across the org's other package repos:

- top-level `permissions: contents: read`; build/test run PR code with **no write token** and `persist-credentials: false`
- packing, the NuGet push and the release upload move to a `release` job gated on `startsWith(github.ref, 'refs/tags/')` with `needs: build` — only that job gets `contents: write`
- `softprops/action-gh-release@v3` (v2 runs on the unsupported Node 20 runtime)

Behavior on a version tag is unchanged: tests still gate the release, the package version still comes from the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)