### PR TITLE
fix(einfo): the monster name is the last field, so it has to opt into escaping

### DIFF
--- a/src/NosCore.Packets/ServerPackets/Inventory/EInfoNpcMonsterPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Inventory/EInfoNpcMonsterPacket.cs
@@ -92,7 +92,7 @@ namespace NosCore.Packets.ServerPackets.Inventory
         [PacketIndex(24)]
         public int Unknown { get; set; } = -1;
 
-        [PacketIndex(25)]
+        [PacketIndex(25, EscapeSpaces = true)]
         public string? Name { get; set; }
     }
 }

--- a/test/NosCore.Packets.Tests/StringFieldSeparatorTests.cs
+++ b/test/NosCore.Packets.Tests/StringFieldSeparatorTests.cs
@@ -10,6 +10,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.Interfaces;
 using NosCore.Packets.ServerPackets.Mates;
 using NosCore.Packets.ServerPackets.Groups;
+using NosCore.Packets.ServerPackets.Inventory;
 using NosCore.Packets.ServerPackets.Miniland;
 using NosCore.Packets.ServerPackets.Visibility;
 using System.Collections.Generic;
@@ -42,7 +43,8 @@ namespace NosCore.Packets.Tests
             {
                 typeof(SeparatorProbePacket), typeof(DottedProbePacket),
                 typeof(ScpPacket), typeof(ScnPacket), typeof(InPacket),
-                typeof(PinitPacket), typeof(MlintroPacket), typeof(MlInfoBrPacket)
+                typeof(PinitPacket), typeof(MlintroPacket), typeof(MlInfoBrPacket),
+                typeof(EInfoNpcMonsterPacket)
             });
 
         [TestMethod]
@@ -118,6 +120,10 @@ namespace NosCore.Packets.Tests
             StringAssert.Contains(
                 Serializer.Serialize(new MlInfoBrPacket { Name = "Bob", MinilandMessage = "hello there" }),
                 "hello^there");
+
+            StringAssert.Contains(
+                Serializer.Serialize(new EInfoNpcMonsterPacket { Name = "Mother Cuby" }),
+                "Mother^Cuby");
         }
 
         [TestMethod]


### PR DESCRIPTION
A trailing string field keeps its spaces unless it opts in, and `Name` is the
last field of `e_info`. Without the flag the line ends

    ... 0 0 -1 Mother Cuby

and everything after the first word is read as extra fields.

It is not a rare shape: 929 of the 1109 monster info lines in a capture carry a
name with a space in it, across 630 distinct names.

### What was tested

Added to `AFieldThatOptsInIsEscapedEvenThoughItIsLast`, next to the two fields
that already opt in. Written red first: without the flag it fails with
`actual: "... -1 Mother Cuby"`, with it the tail reads `Mother^Cuby`.

`dotnet build`: 0 warnings. `dotnet test`: 127/127.

### What was NOT tested

Not played. This is the packet model only; the server side that fills the field
is a separate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serialization of NPC monster names containing spaces, ensuring they are transmitted correctly without field-separation issues.

* **Tests**
  * Added coverage verifying that spaced monster names are properly escaped during serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->