### PR TITLE
Escape the spaces in the monster name

### DIFF
--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/NosCoreIO/NosCore.Packets.git</RepositoryUrl>
 		<PackageIconUrl></PackageIconUrl>
 		<PackageTags>nostale, noscore, chickenapi, nostale private server source, nostale emulator</PackageTags>
-		<Version>21.1.1</Version>
+		<Version>21.1.2</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>NosCore's Packets (Nostale packets) defined over classes</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NosCore.Packets/ServerPackets/Inventory/EInfoNpcMonsterPacket.cs
+++ b/src/NosCore.Packets/ServerPackets/Inventory/EInfoNpcMonsterPacket.cs
@@ -92,7 +92,7 @@ namespace NosCore.Packets.ServerPackets.Inventory
         [PacketIndex(24)]
         public int Unknown { get; set; } = -1;
 
-        [PacketIndex(25)]
+        [PacketIndex(25, EscapeSpaces = true)]
         public string? Name { get; set; }
     }
 }

--- a/test/NosCore.Packets.Tests/SerializerTest.cs
+++ b/test/NosCore.Packets.Tests/SerializerTest.cs
@@ -104,8 +104,24 @@ namespace NosCore.Packets.Tests
                 typeof(Stp2Packet),
                 typeof(TbfPacket),
                 typeof(QrPacket),
-                typeof(SqstPacket)
+                typeof(SqstPacket),
+                typeof(EInfoNpcMonsterPacket)
             });
+
+        // The monster name ends the line, and a last field keeps its spaces unless it asks not
+        // to. 929 of the 1109 monster-info lines in a capture carry a name with a space in it.
+        [TestMethod]
+        public void SerializeEInfoNpcMonsterPacketEscapesTheName()
+        {
+            var testPacket = new EInfoNpcMonsterPacket
+            {
+                Unknown = -1,
+                Name = "Fire Cannoneer"
+            };
+
+            var packet = Serializer.Serialize(testPacket);
+            Assert.IsTrue(packet.EndsWith("-1 Fire^Cannoneer"), packet);
+        }
 
         [TestMethod]
         public void AllPacketsAreSerializable()


### PR DESCRIPTION
## What

`EInfoNpcMonsterPacket.Name` is `[PacketIndex(25)]` — the last field — and a last field keeps its spaces, so free text like a chat message survives the trip. A monster name is a value, not free text, and 929 of the 1109 monster-info lines in a capture carry a name with a space in it.

`EscapeSpaces` already exists for exactly this, and `GInfoPacket`, `MlInfoBrPacket` and `MlintroPacket` declare it. This one did not, so consumers were left calling `Replace(' ', '^')` themselves before handing the value over — which is what NosCoreIO/NosCore#2365 was about to ship.

One attribute argument, and `<Version>` 21.1.1 → 21.1.2.

## Testing

- `SerializeEInfoNpcMonsterPacketEscapesTheName` asserts the **serialised** tail reads `-1 Fire^Cannoneer`. Written red first: without the attribute it fails on the raw `Fire Cannoneer`.
- `dotnet test`: **128 tests**, all green.
- **Not played in game** — this is the wire shape; the client-side effect is the info card drawing the full name instead of stopping at the space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed monster names containing spaces so they are correctly escaped when transmitted, improving packet parsing and display reliability.

* **Maintenance**
  * Updated the packet package version to 21.1.2.

* **Tests**
  * Added coverage to verify correct serialization of monster names with spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->