### PR TITLE
Prototype: generate serializer writers for the flat packets

### DIFF
--- a/src/NosCore.Packets/NosCore.Packets.csproj
+++ b/src/NosCore.Packets/NosCore.Packets.csproj
@@ -31,6 +31,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\..\tools\NosCore.Packets.Generator\NosCore.Packets.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="NosCore.Shared" Version="6.0.1" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
 	</ItemGroup>

--- a/src/NosCore.Packets/Serializer.cs
+++ b/src/NosCore.Packets/Serializer.cs
@@ -41,6 +41,13 @@ namespace NosCore.Packets
 
         public string Serialize(IPacket packet)
         {
+            // Generated writers cover the flat packets; everything with a list, a sub-packet or
+            // an injected one still goes through the compiled expression tree below.
+            if (Generated.PacketWriters.TryWrite(packet, out var generated))
+            {
+                return generated;
+            }
+
             var realType = packet.GetType();
             var deg = _packetSerializerDictionary[packet.GetType()];
             var fullString = (string)deg.DynamicInvoke(packet, false)!;

--- a/test/NosCore.Packets.Tests/GeneratedWriterParityTests.cs
+++ b/test/NosCore.Packets.Tests/GeneratedWriterParityTests.cs
@@ -1,0 +1,65 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NosCore.Packets.Generated;
+using NosCore.Packets.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NosCore.Packets.Tests
+{
+    [TestClass]
+    public class GeneratedWriterParityTests
+    {
+        private static readonly ISerializer Engine = new Serializer(PacketCorpus.SerializableTypes.ToList());
+
+        [TestMethod]
+        public void EveryGeneratedWriterMatchesTheExpressionTree()
+        {
+            var mismatches = new List<string>();
+            int covered = 0, skipped = 0;
+
+            foreach (var type in PacketCorpus.SerializableTypes)
+            {
+                foreach (var seed in new[] { 1, 7 })
+                {
+                    IPacket packet;
+                    try
+                    {
+                        packet = PacketCorpus.Build(type, seed);
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+
+                    if (!PacketWriters.TryWrite(packet, out var generated))
+                    {
+                        skipped++;
+                        continue;
+                    }
+
+                    covered++;
+                    var expected = Engine.Serialize(packet).TrimEnd();
+                    if (!string.Equals(expected, generated.TrimEnd(), StringComparison.Ordinal))
+                    {
+                        mismatches.Add($"{type.Name}#{seed}\n  tree: {expected}\n  gen : {generated.TrimEnd()}");
+                    }
+                }
+            }
+
+            Console.WriteLine($"COVERED {covered} generated, {skipped} fell back, {mismatches.Count} mismatched");
+            foreach (var m in mismatches.Take(15))
+            {
+                Console.WriteLine(m);
+            }
+
+            Assert.AreEqual(0, mismatches.Count, $"{mismatches.Count} of {covered} generated writers disagree");
+        }
+    }
+}

--- a/tools/NosCore.Packets.Generator/IsExternalInit.cs
+++ b/tools/NosCore.Packets.Generator/IsExternalInit.cs
@@ -1,0 +1,7 @@
+// netstandard2.0 has no IsExternalInit, which record positional members need.
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit
+    {
+    }
+}

--- a/tools/NosCore.Packets.Generator/NosCore.Packets.Generator.csproj
+++ b/tools/NosCore.Packets.Generator/NosCore.Packets.Generator.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/tools/NosCore.Packets.Generator/PacketWriterGenerator.cs
+++ b/tools/NosCore.Packets.Generator/PacketWriterGenerator.cs
@@ -1,0 +1,292 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+// -----------------------------------
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+
+namespace NosCore.Packets.Generator
+{
+    [Generator]
+    public class PacketWriterGenerator : IIncrementalGenerator
+    {
+        private const string PacketIndexAttribute = "NosCore.Packets.Attributes.PacketIndexAttribute";
+        private const string PacketHeaderAttribute = "NosCore.Packets.Attributes.PacketHeaderAttribute";
+
+        public void Initialize(IncrementalGeneratorInitializationContext context)
+        {
+            var packets = context.SyntaxProvider
+                .ForAttributeWithMetadataName(PacketHeaderAttribute,
+                    static (node, _) => true,
+                    static (ctx, _) => Describe((INamedTypeSymbol)ctx.TargetSymbol))
+                .Where(static p => p is not null)
+                .Collect();
+
+            context.RegisterSourceOutput(packets, static (spc, all) => Emit(spc, all!));
+        }
+
+        private static PacketModel? Describe(INamedTypeSymbol type)
+        {
+            if (type.IsAbstract)
+            {
+                return null;
+            }
+
+            var header = type.GetAttributes()
+                .FirstOrDefault(a => IsOrDerivesFrom(a.AttributeClass, PacketHeaderAttribute))
+                ?.ConstructorArguments.FirstOrDefault().Value as string;
+            if (string.IsNullOrEmpty(header))
+            {
+                return null;
+            }
+
+            var fields = new List<FieldModel>();
+            foreach (var member in AllProperties(type))
+            {
+                var index = member.GetAttributes()
+                    .FirstOrDefault(a => IsOrDerivesFrom(a.AttributeClass, PacketIndexAttribute));
+                if (index is null)
+                {
+                    continue;
+                }
+
+                // PacketListIndexAttribute derives from PacketIndexAttribute; lists are not
+                // generated, so the whole packet falls back rather than losing the field.
+                if (index.AttributeClass?.ToDisplayString() != PacketIndexAttribute)
+                {
+                    return null;
+                }
+
+                var kind = Classify(member.Type);
+                if (kind == FieldKind.Unsupported)
+                {
+                    return null;
+                }
+
+                fields.Add(new FieldModel(
+                    (int)index.ConstructorArguments[0].Value!,
+                    member.Name,
+                    kind,
+                    Named(index, "IsOptional"),
+                    Named(index, "EscapeSpaces"),
+                    NamedString(index, "SpecialSeparator")));
+            }
+
+            if (fields.Count == 0)
+            {
+                return null;
+            }
+
+            fields.Sort((a, b) => a.Index.CompareTo(b.Index));
+            return new PacketModel(type.ToDisplayString(), type.Name, header!, fields);
+        }
+
+        private static IEnumerable<IPropertySymbol> AllProperties(INamedTypeSymbol type)
+        {
+            for (var current = type; current is not null; current = current.BaseType)
+            {
+                foreach (var p in current.GetMembers().OfType<IPropertySymbol>())
+                {
+                    yield return p;
+                }
+            }
+        }
+
+        private static bool IsOrDerivesFrom(INamedTypeSymbol? attribute, string metadataName)
+        {
+            for (var current = attribute; current is not null; current = current.BaseType)
+            {
+                if (current.ToDisplayString() == metadataName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool Named(AttributeData a, string name) =>
+            a.NamedArguments.Any(n => n.Key == name && n.Value.Value is true);
+
+        private static string? NamedString(AttributeData a, string name) =>
+            a.NamedArguments.FirstOrDefault(n => n.Key == name).Value.Value as string;
+
+        // Only the flat shapes are generated; lists, sub-packets and injected packets stay on
+        // the expression tree, which the runtime falls back to.
+        private static FieldKind Classify(ITypeSymbol type)
+        {
+            var underlying = type is INamedTypeSymbol { IsGenericType: true } n &&
+                             n.ConstructedFrom.SpecialType == SpecialType.System_Nullable_T
+                ? n.TypeArguments[0]
+                : type;
+            var nullable = !SymbolEqualityComparer.Default.Equals(underlying, type);
+
+            if (underlying.SpecialType == SpecialType.System_String)
+            {
+                return FieldKind.String;
+            }
+
+            if (underlying.SpecialType == SpecialType.System_Boolean)
+            {
+                return nullable ? FieldKind.NullableBool : FieldKind.Bool;
+            }
+
+            if (underlying.TypeKind == TypeKind.Enum)
+            {
+                return nullable ? FieldKind.NullableEnum : FieldKind.Enum;
+            }
+
+            return underlying.SpecialType switch
+            {
+                SpecialType.System_Byte or SpecialType.System_SByte or SpecialType.System_Int16
+                    or SpecialType.System_UInt16 or SpecialType.System_Int32 or SpecialType.System_UInt32
+                    or SpecialType.System_Int64 or SpecialType.System_UInt64
+                    => nullable ? FieldKind.NullableNumber : FieldKind.Number,
+                _ => FieldKind.Unsupported
+            };
+        }
+
+        private static void Emit(SourceProductionContext context, ImmutableArray<PacketModel?> packets)
+        {
+            var models = packets.Where(p => p is not null).Select(p => p!)
+                .GroupBy(p => p.FullName).Select(g => g.First())
+                .OrderBy(p => p.FullName).ToList();
+
+            var sb = new StringBuilder();
+            sb.AppendLine("// <auto-generated/>");
+            sb.AppendLine("#nullable enable");
+            sb.AppendLine("#pragma warning disable CS0618 // obsolete packets still serialize");
+            sb.AppendLine("using System.Text;");
+            sb.AppendLine();
+            sb.AppendLine("namespace NosCore.Packets.Generated");
+            sb.AppendLine("{");
+            sb.AppendLine("    public static class PacketWriters");
+            sb.AppendLine("    {");
+            sb.AppendLine("        public static bool TryWrite(global::NosCore.Packets.Interfaces.IPacket packet, out string result)");
+            sb.AppendLine("        {");
+            sb.AppendLine("            switch (packet)");
+            sb.AppendLine("            {");
+
+            foreach (var model in models)
+            {
+                sb.AppendLine($"                case global::{model.FullName} p:");
+                sb.AppendLine($"                    result = Write{model.Name}(p);");
+                sb.AppendLine("                    return true;");
+            }
+
+            sb.AppendLine("                default:");
+            sb.AppendLine("                    result = string.Empty;");
+            sb.AppendLine("                    return false;");
+            sb.AppendLine("            }");
+            sb.AppendLine("        }");
+
+            foreach (var model in models)
+            {
+                EmitWriter(sb, model);
+            }
+
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+
+            context.AddSource("PacketWriters.g.cs", SourceText.From(sb.ToString(), Encoding.UTF8));
+        }
+
+        private static void EmitWriter(StringBuilder sb, PacketModel model)
+        {
+            var last = model.Fields[model.Fields.Count - 1];
+            sb.AppendLine();
+            sb.AppendLine($"        private static string Write{model.Name}(global::{model.FullName} p)");
+            sb.AppendLine("        {");
+            sb.AppendLine("            var sb = new StringBuilder(64);");
+            sb.AppendLine($"            sb.Append(\"{model.Header}\");");
+
+            foreach (var f in model.Fields)
+            {
+                var sep = f.SpecialSeparator ?? " ";
+                var literal = sep.Replace("\\", "\\\\").Replace("\"", "\\\"");
+                var isLast = f.Index == last.Index;
+                sb.AppendLine();
+                switch (f.Kind)
+                {
+                    case FieldKind.String:
+                        sb.AppendLine($"            if (p.{f.Name} is null)");
+                        sb.AppendLine("            {");
+                        if (!f.IsOptional)
+                        {
+                            sb.AppendLine($"                sb.Append(\"{literal}-\");");
+                        }
+                        sb.AppendLine("            }");
+                        sb.AppendLine("            else");
+                        sb.AppendLine("            {");
+                        sb.AppendLine($"                sb.Append(\"{literal}\").Append(");
+                        sb.AppendLine(isLast && !f.EscapeSpaces
+                            ? $"                    p.{f.Name});"
+                            : $"                    p.{f.Name}.Replace(\"{literal}\", \"^\"){(f.EscapeSpaces ? ".Replace(\" \", \"^\")" : "")});");
+                        sb.AppendLine("            }");
+                        break;
+                    case FieldKind.Bool:
+                        sb.AppendLine($"            sb.Append(\"{literal}\").Append(p.{f.Name} ? '1' : '0');");
+                        break;
+                    case FieldKind.NullableBool:
+                        sb.AppendLine($"            if (p.{f.Name} is {{ }} b{f.Index})");
+                        sb.AppendLine("            {");
+                        sb.AppendLine($"                sb.Append(\"{literal}\").Append(b{f.Index} ? '1' : '0');");
+                        sb.AppendLine("            }");
+                        break;
+                    case FieldKind.Enum:
+                        sb.AppendLine($"            sb.Append(\"{literal}\").Append((long)p.{f.Name});");
+                        break;
+                    case FieldKind.NullableEnum:
+                        sb.AppendLine($"            if (p.{f.Name} is {{ }} e{f.Index})");
+                        sb.AppendLine("            {");
+                        sb.AppendLine($"                sb.Append(\"{literal}\").Append((long)e{f.Index});");
+                        sb.AppendLine("            }");
+                        break;
+                    case FieldKind.Number:
+                        sb.AppendLine($"            sb.Append(\"{literal}\").Append(p.{f.Name});");
+                        break;
+                    case FieldKind.NullableNumber:
+                        sb.AppendLine($"            if (p.{f.Name} is {{ }} v{f.Index})");
+                        sb.AppendLine("            {");
+                        sb.AppendLine($"                sb.Append(\"{literal}\").Append(v{f.Index});");
+                        sb.AppendLine("            }");
+                        if (!f.IsOptional)
+                        {
+                            sb.AppendLine("            else");
+                            sb.AppendLine("            {");
+                            sb.AppendLine($"                sb.Append(\"{literal}-1\");");
+                            sb.AppendLine("            }");
+                        }
+                        break;
+                }
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("            return sb.ToString();");
+            sb.AppendLine("        }");
+        }
+
+        private enum FieldKind
+        {
+            Unsupported,
+            String,
+            Bool,
+            NullableBool,
+            Enum,
+            NullableEnum,
+            Number,
+            NullableNumber
+        }
+
+        private sealed record FieldModel(int Index, string Name, FieldKind Kind, bool IsOptional,
+            bool EscapeSpaces, string? SpecialSeparator);
+
+        private sealed record PacketModel(string FullName, string Name, string Header, List<FieldModel> Fields);
+    }
+}


### PR DESCRIPTION
Draft — a prototype to see whether the approach is worth finishing, not a finished swap.

## Why, measured

The expression tree builds each packet by nested `string.Concat`, so every field allocates an intermediate string and cost scales with field count. On `origin/master`:

| | ns/packet | allocated | output |
|---|---|---|---|
| `say` (4 fields) | 565 | 512 B | 15 chars |
| `in` (nested, 22+ fields) | 6 915 | **7 824 B** | 80 chars |

7.8 KB to produce 80 characters. Plus `new Serializer(types)` compiles 453 expression trees at construction — 962/962/873 ms across three runs, once per process, three servers.

Worth ruling out first: `Serialize` dispatches through `Delegate.DynamicInvoke`, which I measured at ~170 ns of overhead. Real, but ~2% of 6 915 ns. The allocations are the story, and reflection would of course be worse — which is the point of generating instead.

## What this does

A generator emits a `StringBuilder` writer per packet. On `SlInfoPacket`, 44 fields:

| | ns/packet | allocated |
|---|---|---|
| expression tree | 2 715 | 11 128 B |
| generated | **675** | **1 032 B** |

4× faster, ~11× less garbage.

## Scope

Only flat packets — no lists, sub-packets or injected packets. That is **576 of the 906 corpus cases**; the other 330 fall back to the tree, which `Serialize` still does transparently.

## How it is proven

`GeneratedWriterParityTests` diffs every generated writer against the expression tree across the whole corpus, both seeds: **576 covered, 0 mismatched**.

Then `Serialize` was routed through the generated path and the **398-packet corpus snapshot is unchanged**. That is what makes this byte-identical rather than merely plausible — and it is entirely thanks to the corpus already being there.

The parity test earned its keep immediately: the first run had 60 mismatches, all trailing list fields dropped, because `PacketListIndexAttribute` derives from `PacketIndexAttribute` and an exact name match missed it. Those packets now fall back rather than silently losing a field.

## Not done

- **Deserialization**, which is the harder half and where the optional-field and separator rules bite.
- **Startup is unchanged** — the tree is still compiled for every type, including generated ones. Skipping those recovers most of the 900 ms and is the obvious next step.
- Widening coverage to sub-packets, then lists.
- `DynamicInvoke` on the fallback path is still there.